### PR TITLE
feat: add download command and related functionality

### DIFF
--- a/.changeset/five-mugs-wash.md
+++ b/.changeset/five-mugs-wash.md
@@ -1,0 +1,5 @@
+---
+"@ucdjs/cli": minor
+---
+
+feat: add new download cmd

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,11 +36,13 @@
     "@luxass/utils": "catalog:prod",
     "@ucdjs/schema-gen": "workspace:*",
     "farver": "catalog:prod",
+    "micromatch": "catalog:prod",
     "p-limit": "catalog:prod",
     "yargs-parser": "catalog:prod"
   },
   "devDependencies": {
     "@luxass/eslint-config": "catalog:dev",
+    "@types/micromatch": "catalog:dev",
     "@types/yargs-parser": "catalog:dev",
     "eslint": "catalog:dev",
     "publint": "catalog:dev",

--- a/packages/cli/src/cmd/download.ts
+++ b/packages/cli/src/cmd/download.ts
@@ -1,0 +1,33 @@
+import type { CLIArguments } from "../cli-utils";
+import { printHelp } from "../cli-utils";
+
+export interface CLIDownloadCmdOptions {
+  flags: CLIArguments<{
+    outputDir?: string;
+    filter?: string;
+  }>;
+  versions: string[];
+}
+
+export async function runDownload({ versions: providedVersions, flags }: CLIDownloadCmdOptions) {
+  if (flags?.help || flags?.h) {
+    printHelp({
+      headline: "Download Unicode Data Files",
+      commandName: "ucd download",
+      usage: "<...versions> [...flags]",
+      tables: {
+        Flags: [
+          ["--output-dir", "Specify the output directory."],
+          ["--filter", "Filter the files to download."],
+          ["--force", "Force the download, even if the files already exist."],
+          ["--help (-h)", "See all available flags."],
+        ],
+      },
+    });
+    return;
+  }
+
+  if (providedVersions.length === 0) {
+    console.error("No versions provided. Please provide at least one version.");
+  }
+}

--- a/packages/cli/src/cmd/download.ts
+++ b/packages/cli/src/cmd/download.ts
@@ -1,4 +1,8 @@
 import type { CLIArguments } from "../cli-utils";
+import { mkdir, writeFile } from "node:fs/promises";
+import path, { dirname, join } from "node:path";
+import { hasUCDPath, mapToUCDPathVersion, UNICODE_TO_UCD_PATH_MAPPINGS, UNICODE_VERSION_METADATA } from "@luxass/unicode-utils";
+import { gray, green, yellow } from "farver/fast";
 import { printHelp } from "../cli-utils";
 
 export interface CLIDownloadCmdOptions {
@@ -8,6 +12,16 @@ export interface CLIDownloadCmdOptions {
   }>;
   versions: string[];
 }
+
+interface FileEntry {
+  name: string;
+  path: string;
+  children?: FileEntry[];
+}
+
+const CONCURRENCY_LIMIT = 3;
+const API_URL = "https://unicode-api.luxass.dev/api/v1";
+const UNICODE_PROXY_URL = "https://unicode-proxy.ucdjs.dev";
 
 export async function runDownload({ versions: providedVersions, flags }: CLIDownloadCmdOptions) {
   if (flags?.help || flags?.h) {
@@ -29,5 +43,149 @@ export async function runDownload({ versions: providedVersions, flags }: CLIDown
 
   if (providedVersions.length === 0) {
     console.error("No versions provided. Please provide at least one version.");
+    return;
+  }
+
+  let versions: { version: string; mappedVersion?: string }[] = [];
+
+  if (providedVersions[0] === "all") {
+    versions = UNICODE_VERSION_METADATA.map((v) => {
+      const mappedVersion = mapToUCDPathVersion(v.version);
+      return {
+        version: v.version,
+        mappedVersion: mappedVersion === v.version ? undefined : mappedVersion,
+      };
+    });
+  } else {
+    versions = providedVersions.map((v) => {
+      const mappedVersion = mapToUCDPathVersion(v);
+      return {
+        version: v,
+        mappedVersion: mappedVersion === v ? undefined : mappedVersion,
+      };
+    });
+  }
+
+  // exit early, if some versions are invalid
+  const invalidVersions = versions.filter(({ version }) => !UNICODE_VERSION_METADATA.find((v) => v.version === version));
+  if (invalidVersions.length > 0) {
+    console.error(
+      `Invalid version(s) provided: ${invalidVersions.join(", ")}. Please provide valid Unicode versions.`,
+    );
+    return;
+  }
+
+  // eslint-disable-next-line node/prefer-global/process
+  const outputDir = flags.outputDir ?? path.join(process.cwd(), "data");
+  await mkdir(outputDir, { recursive: true });
+
+  async function processFileEntries(
+    entries: FileEntry[],
+    basePath: string,
+    versionOutputDir: string,
+    downloadedFiles: string[],
+  ): Promise<void> {
+    const dirPromises: Promise<void>[] = [];
+    const filePromises: Promise<void>[] = [];
+
+    for (const entry of entries) {
+      const outputPath = path.join(versionOutputDir, entry.path);
+
+      if (entry.children) {
+        // create directory and process children
+        dirPromises.push((async () => {
+          await mkdir(outputPath, { recursive: true });
+          await processFileEntries(entry.children!, `${basePath}/${entry.path}`, versionOutputDir, downloadedFiles);
+        })());
+      } else {
+        filePromises.push((async () => {
+          try {
+            await mkdir(dirname(outputPath), { recursive: true });
+            const url = `${UNICODE_PROXY_URL}${basePath}/${entry.path}`;
+            const response = await fetch(url);
+            if (!response.ok) {
+              console.error(`Failed to fetch file: ${entry.path} (${response.status} ${response.statusText})`);
+              return;
+            }
+            const content = await response.text();
+            await writeFile(outputPath, content);
+            downloadedFiles.push(outputPath);
+          } catch (error) {
+            console.error(`Error processing file ${entry.path}:`, error);
+          }
+        })());
+      }
+    }
+
+    // first wait for all directories to be created (and their children processed)
+    await Promise.all(dirPromises);
+
+    // then wait for all file downloads to complete
+    await Promise.all(filePromises);
+  }
+
+  async function processVersion(version: { version: string; mappedVersion?: string }): Promise<void> {
+    // eslint-disable-next-line no-console
+    console.info(`Starting download process for Unicode ${green(version.version)}${version.mappedVersion != null ? gray(` (${green(version.mappedVersion)})`) : ""}`);
+    const downloadedFilesForVersion: string[] = [];
+
+    const versionOutputDir = path.join(outputDir, `v${version.version}`);
+    await mkdir(versionOutputDir, { recursive: true });
+
+    try {
+      // fetch the file list from the new API endpoint
+      const filesResponse = await fetch(`${API_URL}/unicode-files/${version.version}`);
+
+      if (!filesResponse.ok) {
+        console.error(`Failed to fetch file list for version ${version.version}: ${filesResponse.status} ${filesResponse.statusText}`);
+        return;
+      }
+
+      const fileEntries = await filesResponse.json() as FileEntry[];
+
+      if (!Array.isArray(fileEntries)) {
+        console.error(`Invalid response format for version ${version.version}`);
+        return;
+      }
+
+      // filter out any ReadMe.txt files if needed
+      const filteredEntries = fileEntries.filter((entry) =>
+        flags.filter ? entry.path.includes(flags.filter) : true,
+      );
+
+      // create base path for fetching files
+      const correctVersion = version.mappedVersion ?? version.version;
+      const basePath = `/${correctVersion}${hasUCDPath(correctVersion) ? "/ucd" : ""}`;
+
+      // process all files and directories
+      await processFileEntries(filteredEntries, basePath, versionOutputDir, downloadedFilesForVersion);
+
+      if (downloadedFilesForVersion.length === 0) {
+        console.warn(yellow(`No files were downloaded for Unicode ${version.version}.`));
+        return;
+      }
+
+      // eslint-disable-next-line no-console
+      console.info(green(`✓ Downloaded ${downloadedFilesForVersion.length} files for Unicode ${version.version}`));
+      for (const file of downloadedFilesForVersion) {
+        const relativePath = path.relative(versionOutputDir, file);
+        // eslint-disable-next-line no-console
+        console.info(green(`  - ${relativePath}`));
+      }
+    } catch (error) {
+      console.error(`Error processing version ${version.version}:`, error);
+    }
+  }
+
+  const versionGroups = [];
+
+  // group versions into batches of CONCURRENCY_LIMIT
+  for (let i = 0; i < versions.length; i += CONCURRENCY_LIMIT) {
+    versionGroups.push(versions.slice(i, i + CONCURRENCY_LIMIT));
+  }
+
+  // process each batch sequentially, with versions within each batch processed in parallel
+  for (const versionGroup of versionGroups) {
+    await Promise.all(versionGroup.map((version) => processVersion(version)));
   }
 }

--- a/packages/cli/src/cmd/download.ts
+++ b/packages/cli/src/cmd/download.ts
@@ -179,8 +179,8 @@ export async function runDownload({ versions: providedVersions, flags }: CLIDown
             const content = await response.text();
             await writeFile(outputPath, content);
             downloadedFiles.push(outputPath);
-          } catch (error) {
-            errors.push(`Error downloading ${entry.path}: ${error?.message}`);
+          } catch (err) {
+            errors.push(`Error downloading ${entry.path}: ${(err as any).message}`);
           }
         })());
       }
@@ -239,8 +239,8 @@ export async function runDownload({ versions: providedVersions, flags }: CLIDown
           errors.forEach((error) => console.error(red(`  - ${error}`)));
         }
       }
-    } catch (error) {
-      const errorMessage = `Error processing version ${version.version}: ${error?.message}`;
+    } catch (err) {
+      const errorMessage = `Error processing version ${version.version}: ${(err as any).message}`;
       errors.push(errorMessage);
       console.error(red(errorMessage));
     }

--- a/packages/cli/test/cli-utils.test.ts
+++ b/packages/cli/test/cli-utils.test.ts
@@ -1,0 +1,102 @@
+import type { Arguments } from "yargs-parser";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import pkg from "../package.json" with { type: "json" };
+import { parseFlags, resolveCommand, runCommand } from "../src/cli-utils";
+
+const mockRunDownload = vi.fn();
+
+describe("resolveCommand", () => {
+  it("should return 'version' when version flag is present", () => {
+    const flags: Arguments = { _: [], version: true };
+    expect(resolveCommand(flags)).toBe("version");
+  });
+
+  it("should return the command from the third positional argument if it is supported", () => {
+    const flags: Arguments = { _: ["", "", "generate"], version: false };
+    expect(resolveCommand(flags)).toBe("generate");
+  });
+
+  it("should return 'help' when the third positional argument is not a supported command", () => {
+    const flags: Arguments = { _: ["", "", "unknown"], version: false };
+    expect(resolveCommand(flags)).toBe("help");
+  });
+
+  it("should return 'help' when there is no third positional argument", () => {
+    const flags: Arguments = { _: [], version: false };
+    expect(resolveCommand(flags)).toBe("help");
+  });
+});
+
+describe("parseFlags", () => {
+  it("should parse boolean flags correctly", () => {
+    const args = ["--force", "--help"];
+    const flags = parseFlags(args);
+    expect(flags.force).toBe(true);
+    expect(flags.help).toBe(true);
+  });
+
+  it("should use default values when flags are not provided", () => {
+    const flags = parseFlags([]);
+    expect(flags.force).toBe(false);
+  });
+
+  it("should not parse positional arguments as numbers", () => {
+    const args = ["123", "456"];
+    const flags = parseFlags(args);
+    expect(flags._).toEqual(["123", "456"]);
+  });
+
+  it("should allow overriding default values", () => {
+    const args = [
+      "--force",
+    ];
+    const flags = parseFlags(args);
+    expect(flags.force).toBe(true);
+  });
+});
+
+describe("runCommand", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it("should print help message for 'help' command", async () => {
+    const consoleSpy = vi.spyOn(console, "log");
+    await runCommand("help", { _: [] });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("A CLI for working with the Unicode Character Database (UCD)."),
+    );
+  });
+
+  it("should print version for 'version' command", async () => {
+    const consoleSpy = vi.spyOn(console, "log");
+    await runCommand("version", { _: [] });
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`v${pkg.version}`),
+    );
+  });
+
+  it("should handle 'download' command", async () => {
+    vi.mock("../src/cmd/download", () => ({
+      runDownload: mockRunDownload,
+    }));
+
+    const flags = { _: ["", "", "download"], force: false };
+    await runCommand("download", flags);
+
+    expect(mockRunDownload).toHaveBeenCalledWith({
+      flags: expect.objectContaining({
+        force: false,
+      }),
+      versions: [],
+    });
+  });
+
+  it("should throw error for unknown command", async () => {
+    // @ts-expect-error Testing invalid command
+    await expect(runCommand("invalid", { _: [] })).rejects.toThrow(
+      "Error running invalid -- no command found.",
+    );
+  });
+});

--- a/packages/cli/test/cli-utils.test.ts
+++ b/packages/cli/test/cli-utils.test.ts
@@ -12,8 +12,8 @@ describe("resolveCommand", () => {
   });
 
   it("should return the command from the third positional argument if it is supported", () => {
-    const flags: Arguments = { _: ["", "", "generate"], version: false };
-    expect(resolveCommand(flags)).toBe("generate");
+    const flags: Arguments = { _: ["", "", "download"], version: false };
+    expect(resolveCommand(flags)).toBe("download");
   });
 
   it("should return 'help' when the third positional argument is not a supported command", () => {

--- a/packages/cli/test/cmd/download.test.ts
+++ b/packages/cli/test/cmd/download.test.ts
@@ -1,5 +1,9 @@
 /* eslint-disable no-console */
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { HttpResponse, mockFetch } from "#msw-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { testdir } from "vitest-testdirs";
 import * as cliUtils from "../../src/cli-utils";
 import { runDownload } from "../../src/cmd/download";
 
@@ -13,17 +17,93 @@ vi.mock("../../src/cli-utils", async () => {
 
 const originalConsoleLog = console.log;
 const originalConsoleInfo = console.info;
+const originalConsoleError = console.error;
+const originalConsoleWarn = console.warn;
+
+// mock file data
+const mockFileEntries = [
+  {
+    name: "UnicodeData.txt",
+    path: "UnicodeData.txt",
+  },
+  {
+    name: "ReadMe.txt",
+    path: "ReadMe.txt",
+  },
+  {
+    name: "NormalizationTest.txt",
+    path: "NormalizationTest.txt",
+  },
+  {
+    name: "BidiTest.txt",
+    path: "BidiTest.txt",
+  },
+  {
+    name: "BidiCharacterTest.txt",
+    path: "BidiCharacterTest.txt",
+  },
+  {
+    name: "GraphemeBreakTest.txt",
+    path: "GraphemeBreakTest.txt",
+  },
+  {
+    name: "emoji",
+    path: "emoji",
+    children: [
+      {
+        name: "emoji-data.txt",
+        path: "emoji-data.txt",
+      },
+      {
+        name: "emoji-test.txt",
+        path: "emoji-test.txt",
+      },
+    ],
+  },
+];
+
+// sample file contents
+const mockFileContents = {
+  "UnicodeData.txt": "0000;NULL;Cc;0;BN;;;;;N;;;;;",
+  "ReadMe.txt": "# Unicode Data Files README",
+  "NormalizationTest.txt": "@Part0 # Quick test",
+  "BidiTest.txt": "# Bidi Test File",
+  "BidiCharacterTest.txt": "# Bidi Character Test File",
+  "GraphemeBreakTest.txt": "# Grapheme Break Test File",
+  "emoji/emoji-data.txt": "# Emoji Data",
+  "emoji/emoji-test.txt": "# Test emoji sequences",
+};
 
 describe("download command", () => {
   beforeEach(() => {
     vi.resetAllMocks();
     console.log = vi.fn();
     console.info = vi.fn();
+    console.error = vi.fn();
+    console.warn = vi.fn();
+
+    // setup mock api responses
+    mockFetch([
+      ["GET https://unicode-api.luxass.dev/api/v1/unicode-files/16.0.0", () => {
+        return HttpResponse.json(mockFileEntries);
+      }],
+    ]);
+
+    // mock file content responses
+    for (const [filePath, content] of Object.entries(mockFileContents)) {
+      mockFetch([
+        [`GET https://unicode-proxy.ucdjs.dev/16.0.0/ucd/${filePath}`, () => {
+          return new HttpResponse(content, { status: 200 });
+        }],
+      ]);
+    }
   });
 
   afterEach(() => {
     console.log = originalConsoleLog;
     console.info = originalConsoleInfo;
+    console.error = originalConsoleError;
+    console.warn = originalConsoleWarn;
   });
 
   describe("command validation", () => {
@@ -49,6 +129,209 @@ describe("download command", () => {
       });
 
       expect(cliUtils.printHelp).toHaveBeenCalled();
+    });
+  });
+
+  describe("file filtering", () => {
+    it("should download all files when no exclusions are specified", async () => {
+      // create a temporary directory for the test
+      const outputPath = await testdir({});
+
+      await runDownload({
+        versions: ["16.0.0"],
+        flags: {
+          _: ["16.0.0"],
+          outputDir: outputPath,
+        },
+      });
+
+      // check if files were downloaded
+      expect(existsSync(path.join(outputPath, "v16.0.0/UnicodeData.txt"))).toBe(true);
+      expect(existsSync(path.join(outputPath, "v16.0.0/ReadMe.txt"))).toBe(true);
+      expect(existsSync(path.join(outputPath, "v16.0.0/NormalizationTest.txt"))).toBe(true);
+      expect(existsSync(path.join(outputPath, "v16.0.0/BidiTest.txt"))).toBe(true);
+      expect(existsSync(path.join(outputPath, "v16.0.0/emoji/emoji-data.txt"))).toBe(true);
+      expect(existsSync(path.join(outputPath, "v16.0.0/emoji/emoji-test.txt"))).toBe(true);
+    });
+
+    it("should exclude test files when --exclude-test flag is used", async () => {
+      const outputPath = await testdir({});
+
+      await runDownload({
+        versions: ["16.0.0"],
+        flags: {
+          _: ["16.0.0"],
+          outputDir: outputPath,
+          excludeTest: true,
+        },
+      });
+
+      // regular files should exist
+      expect(existsSync(path.join(outputPath, "v16.0.0/UnicodeData.txt"))).toBe(true);
+      expect(existsSync(path.join(outputPath, "v16.0.0/ReadMe.txt"))).toBe(true);
+      expect(existsSync(path.join(outputPath, "v16.0.0/emoji/emoji-data.txt"))).toBe(true);
+
+      // test files should not exist
+      expect(existsSync(path.join(outputPath, "v16.0.0/NormalizationTest.txt"))).toBe(false);
+      expect(existsSync(path.join(outputPath, "v16.0.0/BidiTest.txt"))).toBe(false);
+      expect(existsSync(path.join(outputPath, "v16.0.0/BidiCharacterTest.txt"))).toBe(false);
+      expect(existsSync(path.join(outputPath, "v16.0.0/GraphemeBreakTest.txt"))).toBe(false);
+      expect(existsSync(path.join(outputPath, "v16.0.0/emoji/emoji-test.txt"))).toBe(false);
+    });
+
+    it("should exclude files matching custom glob patterns with --exclude flag", async () => {
+      const outputPath = await testdir({});
+
+      await runDownload({
+        versions: ["16.0.0"],
+        flags: {
+          _: ["16.0.0"],
+          outputDir: outputPath,
+          exclude: "ReadMe.txt,**/emoji/**", // exclude readme and all files in emoji directory
+        },
+      }); // regular files should exist
+      expect(existsSync(path.join(outputPath, "v16.0.0/UnicodeData.txt"))).toBe(true);
+      expect(existsSync(path.join(outputPath, "v16.0.0/NormalizationTest.txt"))).toBe(true);
+      expect(existsSync(path.join(outputPath, "v16.0.0/BidiTest.txt"))).toBe(true);
+      expect(existsSync(path.join(outputPath, "v16.0.0/BidiCharacterTest.txt"))).toBe(true);
+
+      // excluded files should not exist
+      expect(existsSync(path.join(outputPath, "v16.0.0/ReadMe.txt"))).toBe(false);
+      expect(existsSync(path.join(outputPath, "v16.0.0/emoji/emoji-data.txt"))).toBe(false);
+      expect(existsSync(path.join(outputPath, "v16.0.0/emoji/emoji-test.txt"))).toBe(false);
+    });
+
+    it("should combine --exclude and --exclude-test flags", async () => {
+      const outputPath = await testdir({});
+
+      await runDownload({
+        versions: ["16.0.0"],
+        flags: {
+          _: ["16.0.0"],
+          outputDir: outputPath,
+          exclude: "ReadMe.txt",
+          excludeTest: true,
+        },
+      });
+
+      // only unicodedata.txt and emoji-data.txt should exist
+      expect(existsSync(path.join(outputPath, "v16.0.0/UnicodeData.txt"))).toBe(true);
+      expect(existsSync(path.join(outputPath, "v16.0.0/emoji/emoji-data.txt"))).toBe(true);
+
+      // all test files and readme.txt should be excluded
+      expect(existsSync(path.join(outputPath, "v16.0.0/ReadMe.txt"))).toBe(false);
+      expect(existsSync(path.join(outputPath, "v16.0.0/NormalizationTest.txt"))).toBe(false);
+      expect(existsSync(path.join(outputPath, "v16.0.0/BidiTest.txt"))).toBe(false);
+      expect(existsSync(path.join(outputPath, "v16.0.0/BidiCharacterTest.txt"))).toBe(false);
+      expect(existsSync(path.join(outputPath, "v16.0.0/GraphemeBreakTest.txt"))).toBe(false);
+      expect(existsSync(path.join(outputPath, "v16.0.0/emoji/emoji-test.txt"))).toBe(false);
+    });
+  });
+
+  describe("debug output", () => {
+    it("should provide detailed output when debug flag is used", async () => {
+      const outputPath = await testdir({});
+
+      await runDownload({
+        versions: ["16.0.0"],
+        flags: {
+          _: ["16.0.0"],
+          outputDir: outputPath,
+          debug: true,
+        },
+      });
+
+      // check that debug output includes file paths
+      expect(console.info).toHaveBeenCalledWith(
+        expect.stringMatching(/Downloaded \d+ files/),
+      );
+
+      // individual files should be listed in debug mode
+      expect(console.info).toHaveBeenCalledWith(
+        expect.stringMatching(/UnicodeData\.txt/),
+      );
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle API errors gracefully", async () => {
+      // mock api error
+      mockFetch([
+        ["GET https://unicode-api.luxass.dev/api/v1/unicode-files/17.0.0", () => {
+          return new HttpResponse(null, { status: 404 });
+        }],
+      ]);
+
+      const outputPath = await testdir({});
+
+      await runDownload({
+        versions: ["17.0.0"],
+        flags: {
+          _: ["17.0.0"],
+          outputDir: outputPath,
+        },
+      });
+
+      // should log the error
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringMatching(/Failed to fetch file list for version 17.0.0/),
+      );
+    });
+
+    it("should handle file download errors", async () => {
+      // mock successful api response but failed file download
+      mockFetch([
+        ["GET https://unicode-api.luxass.dev/api/v1/unicode-files/16.1.0", () => {
+          return HttpResponse.json([
+            {
+              name: "UnicodeData.txt",
+              path: "UnicodeData.txt",
+            },
+            {
+              name: "MissingFile.txt",
+              path: "MissingFile.txt",
+            },
+          ]);
+        }],
+        ["GET https://unicode-proxy.ucdjs.dev/16.1.0/ucd/UnicodeData.txt", () => {
+          return new HttpResponse("16.1.0 data", { status: 200 });
+        }],
+        ["GET https://unicode-proxy.ucdjs.dev/16.1.0/ucd/MissingFile.txt", () => {
+          return new HttpResponse(null, { status: 404 });
+        }],
+      ]);
+
+      const outputPath = await testdir({});
+
+      await runDownload({
+        versions: ["16.1.0"],
+        flags: {
+          _: ["16.1.0"],
+          outputDir: outputPath,
+          debug: true,
+        },
+      });
+
+      // don't check for specific message or file existence
+      // just verify error handling doesn't crash the process
+      expect(console.error).toHaveBeenCalled();
+    });
+
+    it("should handle invalid versions", async () => {
+      const outputPath = await testdir({});
+
+      await runDownload({
+        versions: ["invalid-version"],
+        flags: {
+          _: ["invalid-version"],
+          outputDir: outputPath,
+        },
+      });
+
+      // should log the error
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringMatching(/Invalid version/),
+      );
     });
   });
 });

--- a/packages/cli/test/cmd/download.test.ts
+++ b/packages/cli/test/cmd/download.test.ts
@@ -1,0 +1,54 @@
+/* eslint-disable no-console */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as cliUtils from "../../src/cli-utils";
+import { runDownload } from "../../src/cmd/download";
+
+vi.mock("../../src/cli-utils", async () => {
+  const actual = await vi.importActual("../../src/cli-utils");
+  return {
+    ...actual,
+    printHelp: vi.fn(),
+  };
+});
+
+const originalConsoleLog = console.log;
+const originalConsoleInfo = console.info;
+
+describe("download command", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    console.log = vi.fn();
+    console.info = vi.fn();
+  });
+
+  afterEach(() => {
+    console.log = originalConsoleLog;
+    console.info = originalConsoleInfo;
+  });
+
+  describe("command validation", () => {
+    it("should print help when help flag is provided", async () => {
+      await runDownload({
+        versions: ["16.0.0"],
+        flags: {
+          _: ["16.0.0"],
+          help: true,
+        },
+      });
+
+      expect(cliUtils.printHelp).toHaveBeenCalled();
+    });
+
+    it("should print help when h flag is provided", async () => {
+      await runDownload({
+        versions: ["16.0.0"],
+        flags: {
+          _: ["16.0.0"],
+          h: true,
+        },
+      });
+
+      expect(cliUtils.printHelp).toHaveBeenCalled();
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     '@luxass/eslint-config':
       specifier: ^4.18.1
       version: 4.18.1
+    '@types/micromatch':
+      specifier: ^4.0.9
+      version: 4.0.9
     '@types/node':
       specifier: ^22.10.0
       version: 22.15.2
@@ -77,6 +80,9 @@ catalogs:
     knitwork:
       specifier: ^1.2.0
       version: 1.2.0
+    micromatch:
+      specifier: ^4.0.8
+      version: 4.0.8
     p-limit:
       specifier: ^6.2.0
       version: 6.2.0
@@ -142,6 +148,9 @@ importers:
       farver:
         specifier: catalog:prod
         version: 0.4.2
+      micromatch:
+        specifier: catalog:prod
+        version: 4.0.8
       p-limit:
         specifier: catalog:prod
         version: 6.2.0
@@ -152,6 +161,9 @@ importers:
       '@luxass/eslint-config':
         specifier: catalog:dev
         version: 4.18.1(@typescript-eslint/utils@8.31.0(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.13)(eslint@9.27.0(jiti@2.4.2))(typescript@5.8.3)(vitest@3.1.4)
+      '@types/micromatch':
+        specifier: catalog:dev
+        version: 4.0.9
       '@types/yargs-parser':
         specifier: catalog:dev
         version: 21.0.3
@@ -1166,6 +1178,9 @@ packages:
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
 
+  '@types/braces@3.0.5':
+    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -1183,6 +1198,9 @@ packages:
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/micromatch@4.0.9':
+    resolution: {integrity: sha512-7V+8ncr22h4UoYRLnLXSpTxjQrNUXtWHGeMPRJt1nULXI57G9bIcpyrHlmrQ7QK24EyyuXvYcSSWAM8GA9nqCg==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -4196,6 +4214,8 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/braces@3.0.5': {}
+
   '@types/cookie@0.6.0': {}
 
   '@types/debug@4.1.12':
@@ -4211,6 +4231,10 @@ snapshots:
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
+
+  '@types/micromatch@4.0.9':
+    dependencies:
+      '@types/braces': 3.0.5
 
   '@types/ms@2.1.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ catalogs:
       specifier: ^1.3.22
       version: 1.3.22
     '@luxass/unicode-utils':
-      specifier: ^0.8.0
-      version: 0.8.0
+      specifier: ^0.9.0
+      version: 0.9.0
     '@luxass/utils':
       specifier: ^2.2.1
       version: 2.2.1
@@ -84,8 +84,8 @@ catalogs:
       specifier: ^21.1.1
       version: 21.1.1
     zod:
-      specifier: ^3.25.13
-      version: 3.25.13
+      specifier: ^3.25.17
+      version: 3.25.17
 
 importers:
 
@@ -132,7 +132,7 @@ importers:
     dependencies:
       '@luxass/unicode-utils':
         specifier: catalog:prod
-        version: 0.8.0
+        version: 0.9.0
       '@luxass/utils':
         specifier: catalog:prod
         version: 2.2.1
@@ -175,16 +175,16 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: catalog:prod
-        version: 1.3.22(zod@3.25.13)
+        version: 1.3.22(zod@3.25.17)
       '@luxass/unicode-utils':
         specifier: catalog:prod
-        version: 0.8.0
+        version: 0.9.0
       '@luxass/utils':
         specifier: catalog:prod
         version: 2.2.1
       ai:
         specifier: catalog:prod
-        version: 4.3.16(react@19.1.0)(zod@3.25.13)
+        version: 4.3.16(react@19.1.0)(zod@3.25.17)
       knitwork:
         specifier: catalog:prod
         version: 1.2.0
@@ -193,7 +193,7 @@ importers:
         version: 6.2.0
       zod:
         specifier: catalog:prod
-        version: 3.25.13
+        version: 3.25.17
     devDependencies:
       '@luxass/eslint-config':
         specifier: catalog:dev
@@ -739,8 +739,8 @@ packages:
       prettier-plugin-astro:
         optional: true
 
-  '@luxass/unicode-utils@0.8.0':
-    resolution: {integrity: sha512-UniG5YOR4PnFg9XQuR/XoicXEwU7ukj73JGHJK4CfvFGYwz892Z2+k+wkx7rH21DhR5zjUXFU9DFiOTzBLPCcQ==}
+  '@luxass/unicode-utils@0.9.0':
+    resolution: {integrity: sha512-RNhEJ2pXiIRhmr/KGtAbl4jy2uwQjXMdRQKHZE1M1IgjkXa4/d8is5HtwxdKKcL0CCO3f4lGAeLOIhR6ACGNfg==}
 
   '@luxass/utils@2.2.1':
     resolution: {integrity: sha512-riQdjsEXmHxaPDcWappVi1YYF/rsveZTvSIsev1m7qYQrRq6aRNYWTVVPhye3Pdf0NCWUNIKIdtrtpHhx+SgYA==}
@@ -3328,47 +3328,47 @@ packages:
     peerDependencies:
       zod: ^3.24.1
 
-  zod@3.25.13:
-    resolution: {integrity: sha512-Q8mvk2iWi7rTDfpQBsu4ziE7A6AxgzJ5hzRyRYQkoV3A3niYsXVwDaP1Kbz3nWav6S+VZ6k2OznFn8ZyDHvIrg==}
+  zod@3.25.17:
+    resolution: {integrity: sha512-8hQzQ/kMOIFbwOgPrm9Sf9rtFHpFUMy4HvN0yEB0spw14aYi0uT5xG5CE2DB9cd51GWNsz+DNO7se1kztHMKnw==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
-  '@ai-sdk/openai@1.3.22(zod@3.25.13)':
+  '@ai-sdk/openai@1.3.22(zod@3.25.17)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.13)
-      zod: 3.25.13
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.17)
+      zod: 3.25.17
 
-  '@ai-sdk/provider-utils@2.2.8(zod@3.25.13)':
+  '@ai-sdk/provider-utils@2.2.8(zod@3.25.17)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 3.25.13
+      zod: 3.25.17
 
   '@ai-sdk/provider@1.1.3':
     dependencies:
       json-schema: 0.4.0
 
-  '@ai-sdk/react@1.2.12(react@19.1.0)(zod@3.25.13)':
+  '@ai-sdk/react@1.2.12(react@19.1.0)(zod@3.25.17)':
     dependencies:
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.13)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.13)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.17)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.17)
       react: 19.1.0
       swr: 2.3.3(react@19.1.0)
       throttleit: 2.1.0
     optionalDependencies:
-      zod: 3.25.13
+      zod: 3.25.17
 
-  '@ai-sdk/ui-utils@1.2.11(zod@3.25.13)':
+  '@ai-sdk/ui-utils@1.2.11(zod@3.25.17)':
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.13)
-      zod: 3.25.13
-      zod-to-json-schema: 3.24.5(zod@3.25.13)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.17)
+      zod: 3.25.17
+      zod-to-json-schema: 3.24.5(zod@3.25.17)
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -3893,7 +3893,7 @@ snapshots:
       - typescript
       - vitest
 
-  '@luxass/unicode-utils@0.8.0':
+  '@luxass/unicode-utils@0.9.0':
     dependencies:
       '@luxass/utils': 2.2.1
 
@@ -4498,15 +4498,15 @@ snapshots:
 
   acorn@8.14.1: {}
 
-  ai@4.3.16(react@19.1.0)(zod@3.25.13):
+  ai@4.3.16(react@19.1.0)(zod@3.25.17):
     dependencies:
       '@ai-sdk/provider': 1.1.3
-      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.13)
-      '@ai-sdk/react': 1.2.12(react@19.1.0)(zod@3.25.13)
-      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.13)
+      '@ai-sdk/provider-utils': 2.2.8(zod@3.25.17)
+      '@ai-sdk/react': 1.2.12(react@19.1.0)(zod@3.25.17)
+      '@ai-sdk/ui-utils': 1.2.11(zod@3.25.17)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
-      zod: 3.25.13
+      zod: 3.25.17
     optionalDependencies:
       react: 19.1.0
 
@@ -6641,10 +6641,10 @@ snapshots:
 
   yoctocolors-cjs@2.1.2: {}
 
-  zod-to-json-schema@3.24.5(zod@3.25.13):
+  zod-to-json-schema@3.24.5(zod@3.25.17):
     dependencies:
-      zod: 3.25.13
+      zod: 3.25.17
 
-  zod@3.25.13: {}
+  zod@3.25.17: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,14 +13,14 @@ catalogs:
     tsx: ^4.19.4
 
   prod:
-    "@luxass/unicode-utils": ^0.8.0
+    "@luxass/unicode-utils": ^0.9.0
     "@luxass/utils": ^2.2.1
     farver: ^0.4.2
     fs-extra: ^11.3.0
     yargs-parser: ^21.1.1
     defu: ^6.1.4
     arktype: ^2.1.20
-    zod: ^3.25.13
+    zod: ^3.25.17
     "@ai-sdk/openai": ^1.3.22
     ai: ^4.3.16
     p-limit: ^6.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,10 +25,12 @@ catalogs:
     ai: ^4.3.16
     p-limit: ^6.2.0
     knitwork: ^1.2.0
+    micromatch: ^4.0.8
 
   dev:
     "@luxass/eslint-config": ^4.18.1
     "@types/fs-extra": ^11.0.4
+    "@types/micromatch": ^4.0.9
     "@types/node": ^22.10.0
     "@types/yargs-parser": ^21.0.3
     eslint: ^9.27.0


### PR DESCRIPTION
This PR removes the old `generate` command, and replaces it with a new more modern `download` command.

This is done to cleanup the CLI, and start from a new beginning with +90% test coverage on our CLI.