### PR TITLE
ci: add pr preview workflow

### DIFF
--- a/.github/workflows/pr-preview.yaml
+++ b/.github/workflows/pr-preview.yaml
@@ -1,0 +1,53 @@
+name: Preview Release
+
+on:
+  pull_request:
+    branches: [main]
+    types: [labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  preview:
+    if: ${{ github.repository_owner == 'ucdjs' && github.event.label.name == 'preview' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+    name: publish preview release
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: setup pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+
+      - name: setup node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: lts/*
+
+      - name: install dependencies
+        run: pnpm install
+
+      - name: build
+        run: pnpm build
+
+      - name: Remove Preview Label
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
+        with:
+          labels: "pr preview"
+
+      - name: publish packages
+        run: |
+          pnpm dlx pkg-pr-new publish --pnpm --compact 'packages/cli' 'packages/schema-gen' 'packages/ucd-store' 'packages/utils'


### PR DESCRIPTION
This PR allows us to add a label to a Pull Requests, which then publishes the packages using pkg.pr.new
