### PR TITLE
feat: switch to picomatch

### DIFF
--- a/.changeset/hungry-birds-go.md
+++ b/.changeset/hungry-birds-go.md
@@ -1,0 +1,5 @@
+---
+"@ucdjs/ucd-store": patch
+---
+
+feat: switch to picomatch

--- a/packages/ucd-store/package.json
+++ b/packages/ucd-store/package.json
@@ -43,13 +43,13 @@
     "@ucdjs/utils": "workspace:*",
     "defu": "catalog:prod",
     "fs-extra": "catalog:prod",
-    "micromatch": "catalog:prod",
+    "picomatch": "catalog:prod",
     "zod": "catalog:prod"
   },
   "devDependencies": {
     "@luxass/eslint-config": "catalog:dev",
     "@types/fs-extra": "catalog:dev",
-    "@types/micromatch": "catalog:dev",
+    "@types/picomatch": "catalog:dev",
     "eslint": "catalog:dev",
     "publint": "catalog:dev",
     "tsdown": "catalog:dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@types/node':
       specifier: ^22.10.0
       version: 22.15.2
+    '@types/picomatch':
+      specifier: ^4.0.0
+      version: 4.0.0
     '@types/yargs-parser':
       specifier: ^21.0.3
       version: 21.0.3
@@ -101,6 +104,9 @@ catalogs:
     p-limit:
       specifier: ^6.2.0
       version: 6.2.0
+    picomatch:
+      specifier: ^4.0.2
+      version: 4.0.2
     yargs-parser:
       specifier: ^21.1.1
       version: 21.1.1
@@ -258,9 +264,9 @@ importers:
       fs-extra:
         specifier: catalog:prod
         version: 11.3.0
-      micromatch:
+      picomatch:
         specifier: catalog:prod
-        version: 4.0.8
+        version: 4.0.2
       zod:
         specifier: catalog:prod
         version: 3.25.42
@@ -271,9 +277,9 @@ importers:
       '@types/fs-extra':
         specifier: catalog:dev
         version: 11.0.4
-      '@types/micromatch':
+      '@types/picomatch':
         specifier: catalog:dev
-        version: 4.0.9
+        version: 4.0.0
       eslint:
         specifier: catalog:dev
         version: 9.27.0(jiti@2.4.2)
@@ -1131,6 +1137,9 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/picomatch@4.0.0':
+    resolution: {integrity: sha512-J1Bng+wlyEERWSgJQU1Pi0HObCLVcr994xT/M+1wcl/yNRTGBupsCxthgkdYG+GCOMaQH7iSVUY3LJVBBqG7MQ==}
 
   '@types/retry@0.12.2':
     resolution: {integrity: sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==}
@@ -4130,6 +4139,8 @@ snapshots:
       undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/picomatch@4.0.0': {}
 
   '@types/retry@0.12.2': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ catalogs:
 
   prod:
     # merge these together when heading inference is implemented better
+    "@luxass/array-utils": ^0.0.0
     "@luxass/unicode-utils": ^0.9.0
     "@luxass/unicode-utils-new": npm:@luxass/unicode-utils@0.12.0-beta.5
     "@luxass/utils": ^2.3.0
@@ -28,11 +29,21 @@ catalogs:
     p-limit: ^6.2.0
     knitwork: ^1.2.0
     micromatch: ^4.0.8
+    picomatch: ^4.0.2
 
   dev:
     "@luxass/eslint-config": ^4.18.1
     "@types/fs-extra": ^11.0.4
     "@types/micromatch": ^4.0.9
+    "@types/p": ^0.0.0
+    "@types/pi": ^0.0.0
+    "@types/pic": ^0.0.0
+    "@types/pico": ^0.0.0
+    "@types/picom": ^0.0.0
+    "@types/picoma": ^0.0.0
+    "@types/picomat": ^0.0.0
+    "@types/picomatc": ^0.0.0
+    "@types/picomatch": ^4.0.0
     "@types/node": ^22.10.0
     "@types/yargs-parser": ^21.0.3
     eslint: ^9.27.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,6 @@ catalogs:
 
   prod:
     # merge these together when heading inference is implemented better
-    "@luxass/array-utils": ^0.0.0
     "@luxass/unicode-utils": ^0.9.0
     "@luxass/unicode-utils-new": npm:@luxass/unicode-utils@0.12.0-beta.5
     "@luxass/utils": ^2.3.0
@@ -35,14 +34,6 @@ catalogs:
     "@luxass/eslint-config": ^4.18.1
     "@types/fs-extra": ^11.0.4
     "@types/micromatch": ^4.0.9
-    "@types/p": ^0.0.0
-    "@types/pi": ^0.0.0
-    "@types/pic": ^0.0.0
-    "@types/pico": ^0.0.0
-    "@types/picom": ^0.0.0
-    "@types/picoma": ^0.0.0
-    "@types/picomat": ^0.0.0
-    "@types/picomatc": ^0.0.0
     "@types/picomatch": ^4.0.0
     "@types/node": ^22.10.0
     "@types/yargs-parser": ^21.0.3


### PR DESCRIPTION
This PR switches from micromatch to use picomatch, this is done since picomatch is a much more lightweight alternative to micromatch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated file matching logic in the download functionality to use a new pattern matching library, improving pattern matching behavior.
- **Chores**
  - Replaced the previous matching library with a new one in dependencies and added corresponding type definitions.
  - Updated workspace configuration to include the new matching library and its type definitions.
- **Documentation**
  - Added a changeset documenting the update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->