### PR TITLE
refactor: move UnicodeVersionFile type to unicode-utils-new/fetch

### DIFF
--- a/packages/ucd-store/src/index.ts
+++ b/packages/ucd-store/src/index.ts
@@ -21,5 +21,4 @@ export {
   createUCDStore,
   type CreateUCDStoreOptions,
   type UCDStore,
-  type UnicodeVersionFile,
 } from "./store";

--- a/packages/ucd-store/src/local.ts
+++ b/packages/ucd-store/src/local.ts
@@ -1,5 +1,6 @@
+import type { UnicodeVersionFile } from "@luxass/unicode-utils-new/fetch";
 import type { FsInterface } from "./fs-interface";
-import type { UCDStore, UCDStoreOptions, UnicodeVersionFile } from "./store";
+import type { UCDStore, UCDStoreOptions } from "./store";
 import path from "node:path";
 import { invariant } from "@luxass/utils";
 import { z } from "zod/v4";

--- a/packages/ucd-store/src/remote.ts
+++ b/packages/ucd-store/src/remote.ts
@@ -1,6 +1,6 @@
-import type { UCDStore, UCDStoreOptions, UnicodeVersionFile } from "./store";
+import type { UCDStore, UCDStoreOptions } from "./store";
 import { hasUCDFolderPath, UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
-import { createClient } from "@luxass/unicode-utils-new/fetch";
+import { createClient, type UnicodeVersionFile } from "@luxass/unicode-utils-new/fetch";
 import { promiseRetry } from "@luxass/utils";
 import { createPathFilter, type FilterFn } from "./filter";
 import { resolveUCDStoreOptions } from "./store";

--- a/packages/ucd-store/src/store.ts
+++ b/packages/ucd-store/src/store.ts
@@ -1,15 +1,9 @@
+import type { UnicodeVersionFile } from "@luxass/unicode-utils-new/fetch";
 import type { MaybePromise, Prettify, RemoveIndexSignature } from "@luxass/utils";
 import type { LocalUCDStore, LocalUCDStoreOptions } from "./local";
 import type { RemoteUCDStore, RemoteUCDStoreOptions } from "./remote";
 import { invariant } from "@luxass/utils";
 import defu from "defu";
-
-// TODO: find another place for this interface
-export interface UnicodeVersionFile {
-  name: string;
-  path: string;
-  children?: UnicodeVersionFile[];
-}
 
 export interface CreateUCDStoreOptions {
   mode?: "remote" | "local";

--- a/packages/ucd-store/test/remote.test.ts
+++ b/packages/ucd-store/test/remote.test.ts
@@ -1,5 +1,5 @@
+import type { UnicodeVersionFile } from "@luxass/unicode-utils-new/fetch";
 import type { Mock } from "vitest";
-import type { UnicodeVersionFile } from "../src/store";
 import { mockFetch } from "#msw-utils";
 import { promiseRetry } from "@luxass/utils";
 import { PRECONFIGURED_FILTERS } from "@ucdjs/ucd-store";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ catalogs:
       specifier: ^0.9.0
       version: 0.9.0
     '@luxass/unicode-utils-new':
-      specifier: npm:@luxass/unicode-utils@0.12.0-beta.6
-      version: 0.12.0-beta.6
+      specifier: npm:@luxass/unicode-utils@0.12.0-beta.7
+      version: 0.12.0-beta.7
     '@luxass/utils':
       specifier: ^2.3.0
       version: 2.3.0
@@ -242,7 +242,7 @@ importers:
     dependencies:
       '@luxass/unicode-utils-new':
         specifier: catalog:prod
-        version: '@luxass/unicode-utils@0.12.0-beta.6'
+        version: '@luxass/unicode-utils@0.12.0-beta.7'
       '@luxass/utils':
         specifier: catalog:prod
         version: 2.3.0
@@ -822,8 +822,8 @@ packages:
       prettier-plugin-astro:
         optional: true
 
-  '@luxass/unicode-utils@0.12.0-beta.6':
-    resolution: {integrity: sha512-UByc2eekZsjt83BJVbf35mQHZRPik9TGlClbprg85BaLMOMJhkEQsxlPx+i3HMcC5Wm599mq3FFvIOwYJneMYA==}
+  '@luxass/unicode-utils@0.12.0-beta.7':
+    resolution: {integrity: sha512-bgBue2gNeXWJTwoXjAqdTpBPsm+SwUL/UEGxPurDHCAcb35zPCzCvhQjtKwx+f94Ip403umJBvPzKW1CQFUAjw==}
 
   '@luxass/unicode-utils@0.9.0':
     resolution: {integrity: sha512-RNhEJ2pXiIRhmr/KGtAbl4jy2uwQjXMdRQKHZE1M1IgjkXa4/d8is5HtwxdKKcL0CCO3f4lGAeLOIhR6ACGNfg==}
@@ -3731,7 +3731,7 @@ snapshots:
       - typescript
       - vitest
 
-  '@luxass/unicode-utils@0.12.0-beta.6':
+  '@luxass/unicode-utils@0.12.0-beta.7':
     dependencies:
       '@luxass/utils': 2.3.0
       defu: 6.1.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ catalogs:
   prod:
     # merge these together when heading inference is implemented better
     "@luxass/unicode-utils": ^0.9.0
-    "@luxass/unicode-utils-new": npm:@luxass/unicode-utils@0.12.0-beta.6
+    "@luxass/unicode-utils-new": npm:@luxass/unicode-utils@0.12.0-beta.7
     "@luxass/utils": ^2.3.0
     farver: ^0.4.2
     fs-extra: ^11.3.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated dependency version for improved compatibility.
- **Refactor**
	- Unified type definitions by sourcing them from an external package, ensuring consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->