### PR TITLE
feat: add UCD file mirroring utilities and filesystem adapter

### DIFF
--- a/.changeset/spotty-bikes-help.md
+++ b/.changeset/spotty-bikes-help.md
@@ -1,0 +1,5 @@
+---
+"@ucdjs/utils": minor
+---
+
+implement fs-adapter for usage in mirrorUCDFiles

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -20,6 +20,8 @@
   },
   "exports": {
     ".": "./dist/index.js",
+    "./types": "./dist/types.js",
+    "./ucd-files": "./dist/ucd-files.js",
     "./package.json": "./package.json"
   },
   "main": "./dist/index.js",

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -1,0 +1,5 @@
+// ONLY STOW TYPES IN HERE WHEN THEY CAN'T BE COLOCATED WITH THE CODE THAT USES THEM
+
+export interface FSAdapter {
+  readFile: (path: string) => Promise<string>;
+}

--- a/packages/utils/src/ucd-files.ts
+++ b/packages/utils/src/ucd-files.ts
@@ -31,27 +31,21 @@ export async function mirrorUCDFiles(): Promise<void> {
  * Currently, it only implements the readFile method, but could be extended with
  * additional functionality as needed.
  *
- * @returns A Promise that resolves to a {@link FSAdapter} implementation
+ * @returns {Promise<FSAdapter>} A Promise that resolves to a {@link FSAdapter} implementation
  * @throws Error if the Node.js fs module cannot be loaded
  */
 export async function createDefaultFSAdapter(): Promise<FSAdapter> {
-  let _fsModule: typeof import("node:fs/promises") = await getFSModule();
+  try {
+    const fsModule = await import("node:fs/promises");
 
-  async function getFSModule(): Promise<typeof import("node:fs/promises")> {
-    if (!_fsModule) {
-      _fsModule = await import("node:fs/promises");
-    }
-
-    if (!_fsModule) {
-      throw new Error("failed to load node:fs module");
-    }
-
-    return _fsModule;
+    return {
+      async readFile(path) {
+        return fsModule.readFile(path, "utf-8");
+      },
+    };
+  } catch (err) {
+    throw new Error("Failed to load file system module", {
+      cause: err,
+    });
   }
-
-  return {
-    async readFile(path) {
-      return _fsModule.readFile(path, "utf-8");
-    },
-  };
 }

--- a/packages/utils/src/ucd-files.ts
+++ b/packages/utils/src/ucd-files.ts
@@ -1,0 +1,57 @@
+import type { FSAdapter } from "./types";
+
+export interface MirrorOptions {
+  /**
+   * List of Unicode versions to download files for.
+   * Each version should be a string representing the Unicode version (e.g., "15.0.0", "14.0.0").
+   */
+  versions: string[];
+
+  /**
+   * Optional base path where files will be downloaded.
+   * Defaults to "./ucd-files" if not provided.
+   */
+  basePath?: string;
+
+  /**
+   * Optional filesystem interface to use for file operations.
+   * If not provided, a default implementation using fs-extra will be used.
+   */
+  fs?: FSAdapter;
+}
+
+export async function mirrorUCDFiles(): Promise<void> {
+  // TODO: Implement the mirroring logic for Unicode files.
+}
+
+/**
+ * Creates a default file system adapter implementation using Node.js fs/promises module.
+ *
+ * This adapter provides basic file system operations needed for UCD file handling.
+ * Currently, it only implements the readFile method, but could be extended with
+ * additional functionality as needed.
+ *
+ * @returns A Promise that resolves to a {@link FSAdapter} implementation
+ * @throws Error if the Node.js fs module cannot be loaded
+ */
+export async function createDefaultFSAdapter(): Promise<FSAdapter> {
+  let _fsModule: typeof import("node:fs/promises") = await getFSModule();
+
+  async function getFSModule(): Promise<typeof import("node:fs/promises")> {
+    if (!_fsModule) {
+      _fsModule = await import("node:fs/promises");
+    }
+
+    if (!_fsModule) {
+      throw new Error("failed to load node:fs module");
+    }
+
+    return _fsModule;
+  }
+
+  return {
+    async readFile(path) {
+      return _fsModule.readFile(path, "utf-8");
+    },
+  };
+}

--- a/packages/utils/test/ucd-files.test.ts
+++ b/packages/utils/test/ucd-files.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDefaultFSAdapter } from "../src/ucd-files";
+
+const mockReadFile = vi.fn();
+
+vi.mock("node:fs/promises", () => ({ readFile: mockReadFile }));
+
+// eslint-disable-next-line test/prefer-lowercase-title
+describe("FS Adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should implement all methods", async () => {
+    const fs = await createDefaultFSAdapter();
+
+    expect(fs.readFile).toBeDefined();
+  });
+
+  it("should read file successfully", async () => {
+    mockReadFile.mockResolvedValue("file content");
+
+    const fs = await createDefaultFSAdapter();
+    const result = await fs.readFile("/test.txt");
+
+    expect(result).toBe("file content");
+    expect(mockReadFile).toHaveBeenCalledWith("/test.txt", "utf-8");
+  });
+
+  describe("when node:fs/promises is not available", () => {
+    beforeEach(() => {
+      vi.resetModules();
+    });
+
+    it("should throw error", async () => {
+      vi.doMock("node:fs/promises", () => {
+        throw new Error("Module not found");
+      });
+
+      await expect(createDefaultFSAdapter()).rejects.toThrow(
+        "Failed to load file system module",
+      );
+    });
+  });
+});

--- a/packages/utils/tsdown.config.ts
+++ b/packages/utils/tsdown.config.ts
@@ -1,7 +1,11 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["./src/index.ts"],
+  entry: [
+    "./src/index.ts",
+    "./src/ucd-files.ts",
+    "./src/types.ts",
+  ],
   exports: true,
   format: ["esm"],
   clean: true,


### PR DESCRIPTION
This PR is a part of #48. To be more specific it moves the file system adapter into the utils package, and initializes a basic mirrorUCDFiles function.

The `mirrorUCDFiles` will be implemented in another PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new utilities for handling Unicode Character Database (UCD) files, including configuration options and a pluggable filesystem adapter.
  - Added the ability to directly import new modules for types and UCD file handling.

- **Bug Fixes**
  - None.

- **Tests**
  - Added unit tests to ensure the reliability of the new filesystem adapter functionality.

- **Chores**
  - Updated documentation and configuration to reflect new entry points and minor package changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->