### PR TITLE
fix(api): update UNICODE_PROXY_ROUTE path to support wildcard

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -1,4 +1,4 @@
-name: deploy to production
+name: deploy to preview
 
 on:
   workflow_dispatch:

--- a/apps/api/src/routes/v1_unicode-proxy.openapi.ts
+++ b/apps/api/src/routes/v1_unicode-proxy.openapi.ts
@@ -52,9 +52,17 @@ export const ROOT_UNICODE_PROXY_ROUTE = createRoute({
 
 export const UNICODE_PROXY_ROUTE = createRoute({
   method: "get",
-  path: "/{path*}",
+  path: "/{path}",
   tags: ["Unicode Proxy"],
   description: "Proxy requests to unicode-proxy.ucdjs.dev",
+  parameters: [
+    {
+      in: "path",
+      name: "path",
+      style: "simple",
+      explode: false,
+    },
+  ],
   request: {
     params: z.object({
       path: z.string().describe("The path to proxy, e.g., 'latest/ucd.all.json'"),

--- a/apps/api/src/routes/v1_unicode-proxy.openapi.ts
+++ b/apps/api/src/routes/v1_unicode-proxy.openapi.ts
@@ -61,13 +61,19 @@ export const UNICODE_PROXY_ROUTE = createRoute({
       name: "path",
       style: "simple",
       explode: false,
+      description: "The path to proxy, e.g., 'latest/ucd.all.json'",
+      required: true,
+      schema: {
+        type: "string",
+        description: "The path to proxy, e.g., 'latest/ucd.all.json'",
+      },
     },
   ],
-  request: {
-    params: z.object({
-      path: z.string().describe("The path to proxy, e.g., 'latest/ucd.all.json'"),
-    }),
-  },
+  // request: {
+  //   params: z.object({
+  //     path: z.string().describe("The path to proxy, e.g., 'latest/ucd.all.json'"),
+  //   }),
+  // },
   responses: {
     200: {
       description: "Successful proxy response",

--- a/apps/api/src/routes/v1_unicode-proxy.openapi.ts
+++ b/apps/api/src/routes/v1_unicode-proxy.openapi.ts
@@ -52,7 +52,7 @@ export const ROOT_UNICODE_PROXY_ROUTE = createRoute({
 
 export const UNICODE_PROXY_ROUTE = createRoute({
   method: "get",
-  path: "/{path}",
+  path: "/{path*}",
   tags: ["Unicode Proxy"],
   description: "Proxy requests to unicode-proxy.ucdjs.dev",
   request: {

--- a/apps/api/src/routes/v1_unicode-proxy.ts
+++ b/apps/api/src/routes/v1_unicode-proxy.ts
@@ -36,6 +36,7 @@ V1_UNICODE_PROXY_ROUTER.openapi(ROOT_UNICODE_PROXY_ROUTE, async (c) => {
 });
 
 V1_UNICODE_PROXY_ROUTER.openapi(UNICODE_PROXY_ROUTE, async (c) => {
+  // @ts-expect-error blah blah
   const { path } = c.req.valid("param");
   console.warn(`Proxying request for path: ${path}`);
 

--- a/apps/api/src/routes/v1_unicode-proxy.ts
+++ b/apps/api/src/routes/v1_unicode-proxy.ts
@@ -37,6 +37,7 @@ V1_UNICODE_PROXY_ROUTER.openapi(ROOT_UNICODE_PROXY_ROUTE, async (c) => {
 
 V1_UNICODE_PROXY_ROUTER.openapi(UNICODE_PROXY_ROUTE, async (c) => {
   const { path } = c.req.valid("param");
+  console.warn(`Proxying request for path: ${path}`);
 
   try {
     const res = await fetch(`${c.env.PROXY_ENDPOINT}/${path}`, {


### PR DESCRIPTION
* Changed the path from `/{path}` to `/{path*}` to allow for proxying multiple path segments.
* This enhances the flexibility of the route for handling various requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path parameter definition for more precise request handling.
* **Chores**
  * Added logging to track proxied request paths for better monitoring.
  * Updated deployment workflow to target preview environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->