### PR TITLE
fix: update paths for OpenAPI generation and linting

### DIFF
--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -2,3 +2,4 @@ node_modules
 .wrangler
 dist
 .dev.vars
+.generated

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -11,7 +11,7 @@
     "test": "pnpm vitest --run",
     "test:watch": "pnpm vitest",
     "lint": "eslint .",
-    "lint:openapi": "pnpm run build:openapi && spectral lint ./node_modules/.openapi/openapi.json",
+    "lint:openapi": "pnpm run build:openapi && spectral lint ./.generated/openapi.json",
     "generate:types": "wrangler types",
     "typecheck": "pnpm run generate:types && tsc --noEmit"
   },

--- a/apps/api/scripts/build-openapi.ts
+++ b/apps/api/scripts/build-openapi.ts
@@ -15,11 +15,11 @@ async function run() {
     },
   ]));
 
-  if (!existsSync(path.join(root.toString(), "./node_modules/.openapi"))) {
-    await mkdir(path.join(root.toString(), "./node_modules/.openapi"), { recursive: true });
+  if (!existsSync(path.join(root.toString(), "./.generated"))) {
+    await mkdir(path.join(root.toString(), "./.generated"), { recursive: true });
   }
 
-  await writeFile(path.join(root.toString(), "./node_modules/.openapi/openapi.json"), JSON.stringify(obj, null, 2));
+  await writeFile(path.join(root.toString(), "./.generated/openapi.json"), JSON.stringify(obj, null, 2));
 }
 
 run().catch((err) => {

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -14,6 +14,12 @@
     "typecheck": {
       "outputs": [".cache/tsbuildinfo.json"]
     },
-    "lint:openapi": {}
+    "lint:openapi": {},
+    "build:openapi": {
+      "cache": false,
+      "outputs": [
+        ".generated/openapi.json"
+      ]
+    }
   }
 }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -34,7 +34,7 @@
     "clean": "git clean -xdf dist node_modules",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "generate:client": "npx openapi-typescript http://api.ucdjs.dev/openapi.json -o ./src/.generated/api.d.ts",
+    "generate:client": "npx openapi-typescript ../../apps/api/.generated/openapi.json -o ./src/.generated/api.d.ts",
     "generate:client:local": "npx openapi-typescript http://localhost:8787/openapi.json -o ./src/.generated/api.d.ts"
   },
   "dependencies": {

--- a/packages/fetch/test/index.test.ts
+++ b/packages/fetch/test/index.test.ts
@@ -249,7 +249,8 @@ describe("unicode API Client", () => {
         };
 
         mockFetch([
-          ["GET https://api.ucdjs.dev/api/v1/unicode-proxy/latest/ucd.all.json", () => {
+          // TODO: remove the need for encodeURIComponent here when https://github.com/openapi-ts/openapi-typescript/pull/2362 is fixed
+          [`GET https://api.ucdjs.dev/api/v1/unicode-proxy/${encodeURIComponent("latest/ucd.all.json")}`, () => {
             return new HttpResponse(JSON.stringify(mockFileResponse), {
               status: 200,
               headers: { "Content-Type": "application/json" },
@@ -311,7 +312,8 @@ describe("unicode API Client", () => {
         };
 
         mockFetch([
-          [`GET https://api.ucdjs.dev/api/v1/unicode-proxy/${path}`, () => {
+          // TODO: remove the need for encodeURIComponent here when https://github.com/openapi-ts/openapi-typescript/pull/2362 is fixed
+          [`GET https://api.ucdjs.dev/api/v1/unicode-proxy/${encodeURIComponent(path)}`, () => {
             return new HttpResponse(JSON.stringify(mockResponse), {
               status: 200,
               headers: { "Content-Type": "application/json" },
@@ -342,7 +344,8 @@ describe("unicode API Client", () => {
         };
 
         mockFetch([
-          ["GET https://api.ucdjs.dev/api/v1/unicode-proxy/non-existent/path", () => {
+          // TODO: remove the need for encodeURIComponent here when https://github.com/openapi-ts/openapi-typescript/pull/2362 is fixed
+          [`GET https://api.ucdjs.dev/api/v1/unicode-proxy/${encodeURIComponent("non-existent/path")}`, () => {
             return new HttpResponse(JSON.stringify(errorResponse), {
               status: 404,
               statusText: "Not Found",
@@ -448,7 +451,11 @@ describe("unicode API Client", () => {
         }],
       ]);
 
-      await client.GET("/api/v1/unicode-versions");
+      await client.GET("/api/v1/unicode-versions", {
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
 
       expect(capturedRequest?.headers.get("Content-Type")).toBe("application/json");
     });

--- a/packages/fetch/turbo.json
+++ b/packages/fetch/turbo.json
@@ -21,6 +21,9 @@
       "cache": false,
       "outputs": [
         "src/.generated/api.d.ts"
+      ],
+      "dependsOn": [
+        "@ucdjs/api#build:openapi"
       ]
     }
   }


### PR DESCRIPTION
* Added `.generated` directory to `.gitignore`.
* Updated `lint:openapi` script to reference `./.generated/openapi.json`.
* Modified `build-openapi.ts` to create `.generated` directory and write OpenAPI JSON there.
* Adjusted `generate:client` script in `fetch/package.json` to use the new OpenAPI path.
* Added `build:openapi` task in `fetch/turbo.json` to depend on the OpenAPI build process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration and scripts to generate and use OpenAPI JSON files from a new local directory.
  * Improved task dependencies to ensure correct build order for API client generation.
  * Updated test mocks to handle URL encoding for path parameters and improved header testing.
  * Adjusted ignore rules to exclude generated files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->