### PR TITLE
feat(api): add files router

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -22,6 +22,7 @@
     "@scalar/hono-api-reference": "catalog:workers",
     "@ucdjs/utils": "workspace:*",
     "@ucdjs/worker-shared": "workspace:*",
+    "apache-autoindex-parse": "catalog:prod",
     "hono": "catalog:workers",
     "zod": "catalog:prod"
   },

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -5,6 +5,7 @@ import { customError, internalServerError, notFound } from "@ucdjs/worker-shared
 import { env } from "hono/adapter";
 import { HTTPException } from "hono/http-exception";
 import { buildOpenApiConfig } from "./openapi";
+import { V1_FILES_ROUTER } from "./routes/v1_files";
 import { V1_UNICODE_PROXY_ROUTER } from "./routes/v1_unicode-proxy";
 import { V1_UNICODE_VERSIONS_ROUTER } from "./routes/v1_unicode-versions";
 
@@ -12,6 +13,7 @@ const app = new OpenAPIHono<HonoEnv>();
 
 app.route("/", V1_UNICODE_VERSIONS_ROUTER);
 app.route("/", V1_UNICODE_PROXY_ROUTER);
+app.route("/", V1_FILES_ROUTER);
 
 app.get(
   "/scalar",

--- a/apps/api/src/routes/v1_files.openapi.ts
+++ b/apps/api/src/routes/v1_files.openapi.ts
@@ -1,0 +1,102 @@
+import { createRoute, z } from "@hono/zod-openapi";
+import { ApiErrorSchema } from "@ucdjs/worker-shared";
+import { UnicodeVersionFileSchema } from "./v1_files.schemas";
+
+export const GET_UNICODE_FILES_BY_VERSION_ROUTE = createRoute({
+  method: "get",
+  path: "/{version}",
+  tags: ["Files"],
+  parameters: [
+    {
+      name: "version",
+      in: "path",
+      required: true,
+      description: "The Unicode version to get files for.",
+      schema: {
+        type: "string",
+      },
+    },
+    {
+      name: "exclude",
+      in: "query",
+      required: false,
+      description: "Optional exclude filters to apply to the file list.",
+      schema: {
+        type: "string",
+      },
+    },
+    {
+      name: "includeTests",
+      in: "query",
+      required: false,
+      description: "Whether to include test files in the response.",
+      schema: {
+        type: "boolean",
+        default: false,
+      },
+    },
+    {
+      name: "includeReadmes",
+      in: "query",
+      required: false,
+      description: "Whether to include Readme files in the response.",
+      schema: {
+        type: "boolean",
+        default: false,
+      },
+    },
+    {
+      name: "includeHTMLFiles",
+      in: "query",
+      required: false,
+      description: "Whether to include HTML files in the response.",
+      schema: {
+        type: "boolean",
+        default: false,
+      },
+    },
+  ],
+  description: "List all UCD files for a specific Unicode version.",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.array(UnicodeVersionFileSchema).openapi("UnicodeVersionFiles"),
+        },
+      },
+      description: "A list of UCD files for the specified Unicode version.",
+    },
+    400: {
+      content: {
+        "application/json": {
+          schema: ApiErrorSchema,
+        },
+      },
+      description: "Bad Request",
+    },
+    429: {
+      content: {
+        "application/json": {
+          schema: ApiErrorSchema,
+        },
+      },
+      description: "Rate Limit Exceeded",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ApiErrorSchema,
+        },
+      },
+      description: "Internal Server Error",
+    },
+    502: {
+      content: {
+        "application/json": {
+          schema: ApiErrorSchema,
+        },
+      },
+      description: "Bad Gateway",
+    },
+  },
+});

--- a/apps/api/src/routes/v1_files.schemas.ts
+++ b/apps/api/src/routes/v1_files.schemas.ts
@@ -1,0 +1,38 @@
+import { z } from "@hono/zod-openapi";
+
+export const BaseUnicodeVersionFileSchema = z.object({
+  name: z.string().openapi({
+    description: "The name of the file or directory.",
+  }),
+
+  path: z.string().openapi({
+    description: "The path to the file or directory.",
+  }),
+});
+
+export interface UnicodeVersionFile {
+  name: string;
+  path: string;
+  children?: UnicodeVersionFile[];
+}
+
+export const UnicodeVersionFileSchema: z.ZodType<UnicodeVersionFile> = z.object({
+  name: z.string().openapi({
+    description: "The name of the file or directory.",
+  }),
+
+  path: z.string().openapi({
+    description: "The path to the file or directory.",
+  }),
+
+  children: z
+    .array(z.lazy(() => UnicodeVersionFileSchema))
+    .optional()
+    .openapi({
+      description: "The children of the directory, if it is a directory.",
+      type: "array",
+      items: {
+        $ref: "#/components/schemas/UnicodeVersionFile",
+      },
+    }),
+}).openapi("UnicodeVersionFile");

--- a/apps/api/src/routes/v1_files.ts
+++ b/apps/api/src/routes/v1_files.ts
@@ -1,0 +1,45 @@
+import type { HonoEnv } from "../types";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { hasUCDFolderPath, resolveUCDVersion, UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
+import { badRequest, internalServerError } from "@ucdjs/worker-shared";
+import { traverse } from "apache-autoindex-parse/traverse";
+import { cache } from "hono/cache";
+import { GET_UNICODE_FILES_BY_VERSION_ROUTE } from "./v1_files.openapi";
+
+export const V1_FILES_ROUTER = new OpenAPIHono<HonoEnv>().basePath("/api/v1/files");
+
+V1_FILES_ROUTER.get("*", cache({
+  cacheName: "unicode-api:files",
+  cacheControl: "max-age=604800",
+}));
+
+V1_FILES_ROUTER.openapi(GET_UNICODE_FILES_BY_VERSION_ROUTE, async (c) => {
+  try {
+    const version = c.req.param("version");
+
+    if (!UNICODE_VERSION_METADATA.map((v) => v.version)
+      .includes(version as typeof UNICODE_VERSION_METADATA[number]["version"])) {
+      return badRequest({
+        message: "Invalid Unicode version",
+      });
+    }
+
+    const mappedVersion = resolveUCDVersion(version);
+    if (!mappedVersion) {
+      return badRequest({
+        message: "Invalid Unicode version",
+      });
+    }
+
+    const extraPath = hasUCDFolderPath(mappedVersion) ? "/ucd" : "";
+
+    const result = await traverse(`https://unicode.org/Public/${mappedVersion}${extraPath}`);
+
+    return c.json(result, 200);
+  } catch (error) {
+    console.error("Error processing directory:", error);
+    return internalServerError({
+      message: "Failed to fetch file mappings",
+    });
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
       '@ucdjs/worker-shared':
         specifier: workspace:*
         version: link:../../packages/worker-shared
+      apache-autoindex-parse:
+        specifier: catalog:prod
+        version: 2.0.0
       hono:
         specifier: catalog:workers
         version: 4.8.3


### PR DESCRIPTION
This PR implements a new route for getting the files available for each unicode version.

Originally this route was available on the unicode-api.luxass.dev, but since i am trying to just call a single endpoint, it makes sense ot move it in here.