### PR TITLE
chore: refactor tsdown configuration across packages

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,9 +4,9 @@
   - changed-files:
       - any-glob-to-any-file: packages/cli/**
 
-"pkg: utils":
+"pkg: env":
   - changed-files:
-      - any-glob-to-any-file: packages/utils/**
+      - any-glob-to-any-file: packages/env/**
 
 "pkg: fetch":
   - changed-files:
@@ -16,17 +16,17 @@
   - changed-files:
       - any-glob-to-any-file: packages/schema-gen/**
 
-"pkg: worker-shared":
-  - changed-files:
-      - any-glob-to-any-file: packages/worker-shared/**
-
 "pkg: ucd-store":
   - changed-files:
       - any-glob-to-any-file: packages/ucd-store/**
 
-"pkg: env":
+"pkg: utils":
   - changed-files:
-      - any-glob-to-any-file: packages/env/**
+      - any-glob-to-any-file: packages/utils/**
+
+"pkg: worker-shared":
+  - changed-files:
+      - any-glob-to-any-file: packages/worker-shared/**
 
 "apps: api":
   - changed-files:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,6 +51,7 @@
     "@luxass/eslint-config": "catalog:linting",
     "@types/yargs-parser": "catalog:dev",
     "@ucdjs/tsconfig": "workspace:*",
+    "@ucdjs/tsdown-config": "workspace:*",
     "eslint": "catalog:linting",
     "publint": "catalog:dev",
     "tsdown": "catalog:dev",

--- a/packages/cli/tsdown.config.ts
+++ b/packages/cli/tsdown.config.ts
@@ -1,23 +1,5 @@
-import { defineConfig } from "tsdown";
+import { createTsdownConfig } from "@ucdjs/tsdown-config";
 
-export default defineConfig({
+export default createTsdownConfig({
   entry: ["./src/cli.ts"],
-  format: ["esm"],
-  exports: true,
-  clean: true,
-  dts: true,
-  treeshake: true,
-  publint: true,
-  tsconfig: "./tsconfig.build.json",
-  inputOptions: {
-    onwarn: (warning, defaultHandler) => {
-      if (warning.code === "UNRESOLVED_IMPORT") {
-        throw new Error(
-          `Unresolved import: ${warning.message}. Please ensure all dependencies are installed and paths are correct.`,
-        );
-      }
-
-      return defaultHandler(warning);
-    },
-  },
 });

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@luxass/eslint-config": "catalog:linting",
     "@ucdjs/tsconfig": "workspace:*",
+    "@ucdjs/tsdown-config": "workspace:*",
     "eslint": "catalog:linting",
     "publint": "catalog:dev",
     "tsdown": "catalog:dev",

--- a/packages/env/tsdown.config.ts
+++ b/packages/env/tsdown.config.ts
@@ -1,25 +1,3 @@
-import { defineConfig } from "tsdown";
+import { createTsdownConfig } from "@ucdjs/tsdown-config";
 
-export default defineConfig({
-  entry: [
-    "./src/index.ts",
-  ],
-  exports: true,
-  format: ["esm"],
-  clean: true,
-  dts: true,
-  treeshake: true,
-  publint: true,
-  tsconfig: "./tsconfig.build.json",
-  inputOptions: {
-    onwarn: (warning, defaultHandler) => {
-      if (warning.code === "UNRESOLVED_IMPORT") {
-        throw new Error(
-          `Unresolved import: ${warning.message}. Please ensure all dependencies are installed and paths are correct.`,
-        );
-      }
-
-      return defaultHandler(warning);
-    },
-  },
-});
+export default createTsdownConfig();

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -47,6 +47,7 @@
     "@luxass/utils": "catalog:prod",
     "@types/picomatch": "catalog:dev",
     "@ucdjs/tsconfig": "workspace:*",
+    "@ucdjs/tsdown-config": "workspace:*",
     "eslint": "catalog:linting",
     "openapi-typescript": "catalog:dev",
     "publint": "catalog:dev",

--- a/packages/fetch/tsdown.config.ts
+++ b/packages/fetch/tsdown.config.ts
@@ -1,25 +1,3 @@
-import { defineConfig } from "tsdown";
+import { createTsdownConfig } from "@ucdjs/tsdown-config";
 
-export default defineConfig({
-  entry: [
-    "./src/index.ts",
-  ],
-  exports: true,
-  format: ["esm"],
-  clean: true,
-  dts: true,
-  treeshake: true,
-  publint: true,
-  tsconfig: "./tsconfig.build.json",
-  inputOptions: {
-    onwarn: (warning, defaultHandler) => {
-      if (warning.code === "UNRESOLVED_IMPORT") {
-        throw new Error(
-          `Unresolved import: ${warning.message}. Please ensure all dependencies are installed and paths are correct.`,
-        );
-      }
-
-      return defaultHandler(warning);
-    },
-  },
-});
+export default createTsdownConfig();

--- a/packages/schema-gen/package.json
+++ b/packages/schema-gen/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@luxass/eslint-config": "catalog:linting",
     "@ucdjs/tsconfig": "workspace:*",
+    "@ucdjs/tsdown-config": "workspace:*",
     "eslint": "catalog:linting",
     "publint": "catalog:dev",
     "tsdown": "catalog:dev",

--- a/packages/schema-gen/tsdown.config.ts
+++ b/packages/schema-gen/tsdown.config.ts
@@ -1,23 +1,3 @@
-import { defineConfig } from "tsdown";
+import { createTsdownConfig } from "@ucdjs/tsdown-config";
 
-export default defineConfig({
-  entry: ["./src/index.ts"],
-  exports: true,
-  format: ["esm"],
-  clean: true,
-  dts: true,
-  treeshake: true,
-  publint: true,
-  tsconfig: "./tsconfig.build.json",
-  inputOptions: {
-    onwarn: (warning, defaultHandler) => {
-      if (warning.code === "UNRESOLVED_IMPORT") {
-        throw new Error(
-          `Unresolved import: ${warning.message}. Please ensure all dependencies are installed and paths are correct.`,
-        );
-      }
-
-      return defaultHandler(warning);
-    },
-  },
-});
+export default createTsdownConfig();

--- a/packages/ucd-store/package.json
+++ b/packages/ucd-store/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@luxass/eslint-config": "catalog:linting",
     "@ucdjs/tsconfig": "workspace:*",
+    "@ucdjs/tsdown-config": "workspace:*",
     "eslint": "catalog:linting",
     "publint": "catalog:dev",
     "tsdown": "catalog:dev",

--- a/packages/ucd-store/tsdown.config.ts
+++ b/packages/ucd-store/tsdown.config.ts
@@ -1,23 +1,3 @@
-import { defineConfig } from "tsdown";
+import { createTsdownConfig } from "@ucdjs/tsdown-config";
 
-export default defineConfig({
-  entry: ["./src/index.ts"],
-  exports: true,
-  format: ["esm"],
-  clean: true,
-  dts: true,
-  treeshake: true,
-  publint: true,
-  tsconfig: "./tsconfig.build.json",
-  inputOptions: {
-    onwarn: (warning, defaultHandler) => {
-      if (warning.code === "UNRESOLVED_IMPORT") {
-        throw new Error(
-          `Unresolved import: ${warning.message}. Please ensure all dependencies are installed and paths are correct.`,
-        );
-      }
-
-      return defaultHandler(warning);
-    },
-  },
-});
+export default createTsdownConfig();

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -52,6 +52,7 @@
     "@luxass/eslint-config": "catalog:linting",
     "@types/picomatch": "catalog:dev",
     "@ucdjs/tsconfig": "workspace:*",
+    "@ucdjs/tsdown-config": "workspace:*",
     "eslint": "catalog:linting",
     "publint": "catalog:dev",
     "tsdown": "catalog:dev",

--- a/packages/utils/tsdown.config.ts
+++ b/packages/utils/tsdown.config.ts
@@ -1,6 +1,6 @@
-import { defineConfig } from "tsdown";
+import { createTsdownConfig } from "@ucdjs/tsdown-config";
 
-export default defineConfig({
+export default createTsdownConfig({
   entry: [
     "./src/index.ts",
     "./src/ucd-files.ts",
@@ -11,22 +11,4 @@ export default defineConfig({
     "./src/fs-bridge/node.ts",
     "./src/fs-bridge/http.ts",
   ],
-  exports: true,
-  format: ["esm"],
-  clean: true,
-  dts: true,
-  treeshake: true,
-  publint: true,
-  tsconfig: "./tsconfig.build.json",
-  inputOptions: {
-    onwarn: (warning, defaultHandler) => {
-      if (warning.code === "UNRESOLVED_IMPORT") {
-        throw new Error(
-          `Unresolved import: ${warning.message}. Please ensure all dependencies are installed and paths are correct.`,
-        );
-      }
-
-      return defaultHandler(warning);
-    },
-  },
 });

--- a/packages/worker-shared/package.json
+++ b/packages/worker-shared/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@luxass/eslint-config": "catalog:linting",
     "@ucdjs/tsconfig": "workspace:*",
+    "@ucdjs/tsdown-config": "workspace:*",
     "eslint": "catalog:linting",
     "publint": "catalog:dev",
     "tsdown": "catalog:dev",

--- a/packages/worker-shared/tsdown.config.ts
+++ b/packages/worker-shared/tsdown.config.ts
@@ -1,25 +1,3 @@
-import { defineConfig } from "tsdown";
+import { createTsdownConfig } from "@ucdjs/tsdown-config";
 
-export default defineConfig({
-  entry: [
-    "./src/index.ts",
-  ],
-  exports: true,
-  format: ["esm"],
-  clean: true,
-  dts: true,
-  treeshake: true,
-  publint: true,
-  tsconfig: "./tsconfig.build.json",
-  inputOptions: {
-    onwarn: (warning, defaultHandler) => {
-      if (warning.code === "UNRESOLVED_IMPORT") {
-        throw new Error(
-          `Unresolved import: ${warning.message}. Please ensure all dependencies are installed and paths are correct.`,
-        );
-      }
-
-      return defaultHandler(warning);
-    },
-  },
-});
+export default createTsdownConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -325,6 +325,9 @@ importers:
       '@ucdjs/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@ucdjs/tsdown-config':
+        specifier: workspace:*
+        version: link:../../tooling/tsdown-config
       eslint:
         specifier: catalog:linting
         version: 9.28.0(jiti@2.4.2)
@@ -353,6 +356,9 @@ importers:
       '@ucdjs/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@ucdjs/tsdown-config':
+        specifier: workspace:*
+        version: link:../../tooling/tsdown-config
       eslint:
         specifier: catalog:linting
         version: 9.28.0(jiti@2.4.2)
@@ -387,6 +393,9 @@ importers:
       '@ucdjs/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@ucdjs/tsdown-config':
+        specifier: workspace:*
+        version: link:../../tooling/tsdown-config
       eslint:
         specifier: catalog:linting
         version: 9.28.0(jiti@2.4.2)
@@ -439,6 +448,9 @@ importers:
       '@ucdjs/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@ucdjs/tsdown-config':
+        specifier: workspace:*
+        version: link:../../tooling/tsdown-config
       eslint:
         specifier: catalog:linting
         version: 9.28.0(jiti@2.4.2)
@@ -485,6 +497,9 @@ importers:
       '@ucdjs/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@ucdjs/tsdown-config':
+        specifier: workspace:*
+        version: link:../../tooling/tsdown-config
       eslint:
         specifier: catalog:linting
         version: 9.28.0(jiti@2.4.2)
@@ -537,6 +552,9 @@ importers:
       '@ucdjs/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@ucdjs/tsdown-config':
+        specifier: workspace:*
+        version: link:../../tooling/tsdown-config
       eslint:
         specifier: catalog:linting
         version: 9.28.0(jiti@2.4.2)
@@ -571,6 +589,9 @@ importers:
       '@ucdjs/tsconfig':
         specifier: workspace:*
         version: link:../../tooling/tsconfig
+      '@ucdjs/tsdown-config':
+        specifier: workspace:*
+        version: link:../../tooling/tsdown-config
       eslint:
         specifier: catalog:linting
         version: 9.28.0(jiti@2.4.2)
@@ -585,6 +606,19 @@ importers:
         version: 5.8.3
 
   tooling/tsconfig: {}
+
+  tooling/tsdown-config:
+    dependencies:
+      tsdown:
+        specifier: catalog:dev
+        version: 0.12.7(publint@0.3.12)(typescript@5.8.3)
+    devDependencies:
+      '@ucdjs/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      typescript:
+        specifier: catalog:dev
+        version: 5.8.3
 
 packages:
 

--- a/tooling/tsconfig/base.json
+++ b/tooling/tsconfig/base.json
@@ -6,17 +6,17 @@
     "paths": {
       "#msw-utils": ["./test/msw-utils/msw.ts"],
       "@ucdjs/cli": ["./packages/cli/src/cli.ts"],
-      "@ucdjs/utils": ["./packages/utils/src/index.ts"],
-      "@ucdjs/utils/ucd-files": ["./packages/utils/src/ucd-files.ts"],
-      "@ucdjs/utils/types": ["./packages/utils/src/types.ts"],
-      "@ucdjs/utils/fs-bridge": ["./packages/utils/src/fs-bridge.ts"],
-      "@ucdjs/utils/fs-bridge/node": ["./packages/utils/src/fs-bridge/node.ts"],
-      "@ucdjs/utils/fs-bridge/http": ["./packages/utils/src/fs-bridge/http.ts"],
+      "@ucdjs/env": ["./packages/env/src/index.ts"],
+      "@ucdjs/fetch": ["./packages/fetch/src/index.ts"],
       "@ucdjs/schema-gen": ["./packages/schema-gen/src/index.ts"],
       "@ucdjs/ucd-store": ["./packages/ucd-store/src/index.ts"],
-      "@ucdjs/fetch": ["./packages/fetch/src/index.ts"],
+      "@ucdjs/utils": ["./packages/utils/src/index.ts"],
+      "@ucdjs/utils/fs-bridge": ["./packages/utils/src/fs-bridge.ts"],
+      "@ucdjs/utils/fs-bridge/http": ["./packages/utils/src/fs-bridge/http.ts"],
+      "@ucdjs/utils/fs-bridge/node": ["./packages/utils/src/fs-bridge/node.ts"],
+      "@ucdjs/utils/types": ["./packages/utils/src/types.ts"],
+      "@ucdjs/utils/ucd-files": ["./packages/utils/src/ucd-files.ts"],
       "@ucdjs/worker-shared": ["./packages/worker-shared/src/index.ts"],
-      "@ucdjs/env": ["./packages/env/src/index.ts"],
     }
   }
 }

--- a/tooling/tsdown-config/base.js
+++ b/tooling/tsdown-config/base.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef {import("tsdown").Options} TsdownOptions
+ */
+
+/**
+ * Base tsdown configuration shared across all packages
+ * @type {TsdownOptions}
+ */
+export const baseConfig = {
+  exports: true,
+  format: ["esm"],
+  clean: true,
+  dts: true,
+  treeshake: true,
+  publint: true,
+  tsconfig: "./tsconfig.build.json",
+  inputOptions: {
+    onwarn: (warning, defaultHandler) => {
+      if (warning.code === "UNRESOLVED_IMPORT") {
+        throw new Error(
+          `Unresolved import: ${warning.message}. Please ensure all dependencies are installed and paths are correct.`,
+        );
+      }
+
+      return defaultHandler(warning);
+    },
+  },
+};

--- a/tooling/tsdown-config/index.js
+++ b/tooling/tsdown-config/index.js
@@ -1,0 +1,22 @@
+import { defineConfig } from "tsdown";
+import { baseConfig } from "./base.js";
+
+/**
+ * @typedef {import("tsdown").Options} TsdownOptions
+ */
+
+/**
+ * Creates a tsdown configuration with the base shared settings
+ * and allows for package-specific overrides.
+ * @param {TsdownOptions} [overrides={}] - Package-specific configuration overrides
+ * @returns {ReturnType<import("tsdown").defineConfig>} - The configured tsdown configuration
+ */
+export function createTsdownConfig(overrides = {}) {
+  return defineConfig({
+    ...baseConfig,
+    ...overrides,
+    entry: overrides.entry || ["./src/index.ts"],
+  });
+}
+
+export { baseConfig } from "./base.js";

--- a/tooling/tsdown-config/package.json
+++ b/tooling/tsdown-config/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@ucdjs/tsdown-config",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./index.js",
+    "./base": "./base.js"
+  },
+  "files": [
+    "index.js",
+    "base.js"
+  ],
+  "dependencies": {
+    "tsdown": "catalog:dev"
+  },
+  "devDependencies": {
+    "@ucdjs/tsconfig": "workspace:*",
+    "typescript": "catalog:dev"
+  }
+}

--- a/tooling/tsdown-config/tsconfig.json
+++ b/tooling/tsdown-config/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "@ucdjs/tsconfig/base",
+  "include": [
+    "*.js"
+  ]
+}


### PR DESCRIPTION
* Updated `tsdown.config.ts` files to use `createTsdownConfig` from `@ucdjs/tsdown-config`.
* Modified package.json files to include `@ucdjs/tsdown-config` as a dependency.
* Adjusted paths in `base.json` for improved module resolution.
* Introduced base configuration in `@ucdjs/tsdown-config` for shared settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Simplified and unified TypeScript documentation build configurations across multiple packages for easier maintenance.
  * Added a shared configuration package for TypeScript documentation builds and updated dependencies accordingly.
  * Improved and reorganized label mappings for package management.
  * Updated TypeScript path aliases for better project structure and clarity.

* **Refactor**
  * Replaced detailed, package-specific documentation config files with a streamlined, shared setup.

* **Documentation**
  * No changes to user-facing documentation content, but internal configuration for documentation generation was standardized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->