### PR TITLE
feat(api): add API routes for Unicode versions and mappings

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,12 +8,14 @@ import { buildOpenApiConfig } from "./openapi";
 import { V1_FILES_ROUTER } from "./routes/v1_files";
 import { V1_UNICODE_PROXY_ROUTER } from "./routes/v1_unicode-proxy";
 import { V1_UNICODE_VERSIONS_ROUTER } from "./routes/v1_unicode-versions";
+import { V1_VERSIONS_ROUTER } from "./routes/v1_versions";
 
 const app = new OpenAPIHono<HonoEnv>();
 
 setupCors(app);
 
 app.route("/", V1_UNICODE_VERSIONS_ROUTER);
+app.route("/", V1_VERSIONS_ROUTER);
 app.route("/", V1_UNICODE_PROXY_ROUTER);
 app.route("/", V1_FILES_ROUTER);
 

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -92,6 +92,18 @@ export function buildOpenApiConfig(version: string, servers: NonNullable<OpenAPI
           without any additional processing or transformation.
         `,
       },
+      {
+        name: "Versions",
+        description: dedent`
+          Endpoints for accessing information about Unicode versions.
+
+          These endpoints allow you to retrieve metadata about different Unicode versions,
+          including version numbers, release dates, and available data files.
+
+          They also contain endpoints for listing all available Unicode versions,
+          retrieving the latest version, and accessing specific version metadata.
+        `,
+      },
     ],
     servers,
   } satisfies OpenAPIObjectConfig;

--- a/apps/api/src/routes/v1_versions.openapi.ts
+++ b/apps/api/src/routes/v1_versions.openapi.ts
@@ -67,4 +67,3 @@ export const GET_UNICODE_MAPPINGS = createRoute({
     },
   },
 });
-

--- a/apps/api/src/routes/v1_versions.openapi.ts
+++ b/apps/api/src/routes/v1_versions.openapi.ts
@@ -92,3 +92,28 @@ export const GET_UNICODE_VERSION_METADATA = createRoute({
     },
   },
 });
+
+export const GET_SUPPORTED_VERSIONS_ROUTE = createRoute({
+  method: "get",
+  path: "/supported",
+  tags: ["Versions"],
+  description: "Get only the Unicode versions that are currently supported by the API",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: UnicodeVersionMetadataSchema,
+        },
+      },
+      description: "List of supported Unicode versions from the unicode-utils package",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ApiErrorSchema,
+        },
+      },
+      description: "Internal Server Error",
+    },
+  },
+});

--- a/apps/api/src/routes/v1_versions.openapi.ts
+++ b/apps/api/src/routes/v1_versions.openapi.ts
@@ -1,0 +1,94 @@
+import { createRoute, z } from "@hono/zod-openapi";
+import { ApiErrorSchema } from "@ucdjs/worker-shared";
+import { UnicodeVersionMappingsSchema, UnicodeVersionMetadataSchema, UnicodeVersionSchema } from "./v1_versions.schemas";
+
+export const LIST_ALL_UNICODE_VERSIONS_ROUTE = createRoute({
+  method: "get",
+  path: "/releases",
+  tags: ["Versions"],
+  description: "List all Unicode Versions available, including metadata and support status.",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: z.array(UnicodeVersionSchema).openapi("UnicodeVersions"),
+        },
+      },
+      description: "A list of Unicode versions with metadata and support status.",
+    },
+    404: {
+      content: {
+        "application/json": {
+          schema: ApiErrorSchema,
+        },
+      },
+      description: "Not Found",
+    },
+    429: {
+      content: {
+        "application/json": {
+          schema: ApiErrorSchema,
+        },
+      },
+      description: "Rate Limit Exceeded",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ApiErrorSchema,
+        },
+      },
+      description: "Internal Server Error",
+    },
+  },
+});
+
+export const GET_UNICODE_MAPPINGS = createRoute({
+  method: "get",
+  path: "/mappings",
+  tags: ["Versions"],
+  description: "List all Unicode Versions mappings",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: UnicodeVersionMappingsSchema,
+        },
+      },
+      description: "A list of Unicode versions mappings",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ApiErrorSchema,
+        },
+      },
+      description: "Internal Server Error",
+    },
+  },
+});
+
+export const GET_UNICODE_VERSION_METADATA = createRoute({
+  method: "get",
+  path: "/metadata",
+  tags: ["Versions"],
+  description: "Get Unicode version metadata for all supported versions",
+  responses: {
+    200: {
+      content: {
+        "application/json": {
+          schema: UnicodeVersionMetadataSchema,
+        },
+      },
+      description: "Unicode version metadata for all supported versions",
+    },
+    500: {
+      content: {
+        "application/json": {
+          schema: ApiErrorSchema,
+        },
+      },
+      description: "Internal Server Error",
+    },
+  },
+});

--- a/apps/api/src/routes/v1_versions.openapi.ts
+++ b/apps/api/src/routes/v1_versions.openapi.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { ApiErrorSchema } from "@ucdjs/worker-shared";
-import { UnicodeVersionMappingsSchema, UnicodeVersionMetadataSchema, UnicodeVersionSchema } from "./v1_versions.schemas";
+import { UnicodeVersionMappingsSchema, UnicodeVersionSchema } from "./v1_versions.schemas";
 
 export const LIST_ALL_UNICODE_VERSIONS_ROUTE = createRoute({
   method: "get",
@@ -68,52 +68,3 @@ export const GET_UNICODE_MAPPINGS = createRoute({
   },
 });
 
-export const GET_UNICODE_VERSION_METADATA = createRoute({
-  method: "get",
-  path: "/metadata",
-  tags: ["Versions"],
-  description: "Get Unicode version metadata for all supported versions",
-  responses: {
-    200: {
-      content: {
-        "application/json": {
-          schema: UnicodeVersionMetadataSchema,
-        },
-      },
-      description: "Unicode version metadata for all supported versions",
-    },
-    500: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Internal Server Error",
-    },
-  },
-});
-
-export const GET_SUPPORTED_VERSIONS_ROUTE = createRoute({
-  method: "get",
-  path: "/supported",
-  tags: ["Versions"],
-  description: "Get only the Unicode versions that are currently supported by the API",
-  responses: {
-    200: {
-      content: {
-        "application/json": {
-          schema: UnicodeVersionMetadataSchema,
-        },
-      },
-      description: "List of supported Unicode versions from the unicode-utils package",
-    },
-    500: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Internal Server Error",
-    },
-  },
-});

--- a/apps/api/src/routes/v1_versions.schemas.ts
+++ b/apps/api/src/routes/v1_versions.schemas.ts
@@ -20,9 +20,6 @@ export const UnicodeVersionSchema = z.object({
   ]).openapi({
     description: "The status of the Unicode version. 'unsupported' means the version exists but is not yet supported by the API.",
   }),
-  supported: z.boolean().openapi({
-    description: "Whether this Unicode version is supported by the current API implementation.",
-  }),
 }).openapi("UnicodeVersion");
 
 export type UnicodeVersion = z.infer<typeof UnicodeVersionSchema>;

--- a/apps/api/src/routes/v1_versions.schemas.ts
+++ b/apps/api/src/routes/v1_versions.schemas.ts
@@ -1,0 +1,38 @@
+import { z } from "@hono/zod-openapi";
+
+export const UnicodeVersionSchema = z.object({
+  version: z.string().openapi({
+    description: "The version of the Unicode standard.",
+  }),
+  documentationUrl: z.string().url().openapi({
+    description: "The URL to the Unicode version documentation.",
+  }),
+  date: z.string().regex(/^\d{4}$/, "Year must be a four-digit number").openapi({
+    description: "The year of the Unicode version.",
+  }).nullable(),
+  ucdUrl: z.string().url().openapi({
+    description: "The URL to the Unicode Character Database (UCD) for this version.",
+  }),
+  status: z.union([
+    z.literal("stable"),
+    z.literal("draft"),
+    z.literal("unsupported"),
+  ]).openapi({
+    description: "The status of the Unicode version. 'unsupported' means the version exists but is not yet supported by the API.",
+  }),
+  supported: z.boolean().openapi({
+    description: "Whether this Unicode version is supported by the current API implementation.",
+  }),
+}).openapi("UnicodeVersion");
+
+export type UnicodeVersion = z.infer<typeof UnicodeVersionSchema>;
+
+export const UnicodeVersionMappingsSchema = z.record(
+  z.string(),
+  z.string(),
+).openapi("UnicodeVersionMappings");
+
+export const UnicodeVersionMetadataSchema = z.record(
+  z.string(),
+  z.any(),
+).openapi("UnicodeVersionMetadata");

--- a/apps/api/src/routes/v1_versions.ts
+++ b/apps/api/src/routes/v1_versions.ts
@@ -31,7 +31,7 @@ V1_VERSIONS_ROUTER.openapi(LIST_ALL_UNICODE_VERSIONS_ROUTE, async (c) => {
     );
 
     if (!tableMatch) {
-      return notFound({
+      return notFound(c, {
         message: "Unicode versions table not found",
       });
     }
@@ -68,7 +68,7 @@ V1_VERSIONS_ROUTER.openapi(LIST_ALL_UNICODE_VERSIONS_ROUTE, async (c) => {
         status = "unsupported";
       }
 
-      versions.unshift({
+      versions.push({
         version,
         documentationUrl: documentationUrl!,
         date: dateMatch[1]!,

--- a/apps/api/src/routes/v1_versions.ts
+++ b/apps/api/src/routes/v1_versions.ts
@@ -56,10 +56,11 @@ V1_VERSIONS_ROUTER.openapi(LIST_ALL_UNICODE_VERSIONS_ROUTE, async (c) => {
 
       // look for a year pattern anywhere in the row
       const dateMatch = row.match(/<td[^>]*>(\d{4})<\/td>/);
-      if (!dateMatch) continue;
+      if (!dateMatch || !dateMatch[1]) continue;
+      
       const ucdVersion = resolveUCDVersion(version);
-      const ucdUrl = `https://www.unicode.org/Public/${ucdVersion}/${hasUCDFolderPath(ucdVersion) ? "ucd" : ""}`;
-
+      const ucdPath = hasUCDFolderPath(ucdVersion) ? "ucd" : "";
+      const ucdUrl = `https://www.unicode.org/Public/${ucdVersion}/${ucdPath}`;
       // Determine status based on draft, supported versions, and current implementation
       let status: "stable" | "draft" | "unsupported" = "stable";
       if (draft === version) {

--- a/apps/api/src/routes/v1_versions.ts
+++ b/apps/api/src/routes/v1_versions.ts
@@ -1,7 +1,12 @@
 import type { HonoEnv } from "../types";
 import type { UnicodeVersion } from "./v1_versions.schemas";
 import { OpenAPIHono } from "@hono/zod-openapi";
-import { getCurrentDraftVersion, hasUCDFolderPath, resolveUCDVersion, UNICODE_TO_UCD_VERSION_MAPPINGS, UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
+import {
+  getCurrentDraftVersion,
+  hasUCDFolderPath,
+  resolveUCDVersion,
+  UNICODE_TO_UCD_VERSION_MAPPINGS,
+} from "@luxass/unicode-utils-new";
 import { internalServerError, notFound } from "@ucdjs/worker-shared";
 import { cache } from "hono/cache";
 import { GET_UNICODE_MAPPINGS, LIST_ALL_UNICODE_VERSIONS_ROUTE } from "./v1_versions.openapi";
@@ -102,4 +107,3 @@ V1_VERSIONS_ROUTER.openapi(LIST_ALL_UNICODE_VERSIONS_ROUTE, async (c) => {
 V1_VERSIONS_ROUTER.openapi(GET_UNICODE_MAPPINGS, async (c) => {
   return c.json(UNICODE_TO_UCD_VERSION_MAPPINGS, 200);
 });
-

--- a/apps/api/src/routes/v1_versions.ts
+++ b/apps/api/src/routes/v1_versions.ts
@@ -1,0 +1,121 @@
+import type { HonoEnv } from "../types";
+import type { UnicodeVersion } from "./v1_versions.schemas";
+import { OpenAPIHono } from "@hono/zod-openapi";
+import { getCurrentDraftVersion, hasUCDFolderPath, resolveUCDVersion, UNICODE_TO_UCD_VERSION_MAPPINGS, UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
+import { internalServerError, notFound } from "@ucdjs/worker-shared";
+import { cache } from "hono/cache";
+import { GET_UNICODE_MAPPINGS, GET_UNICODE_VERSION_METADATA, LIST_ALL_UNICODE_VERSIONS_ROUTE } from "./v1_versions.openapi";
+
+export const V1_VERSIONS_ROUTER = new OpenAPIHono<HonoEnv>().basePath("/api/v1/versions");
+
+V1_VERSIONS_ROUTER.get("*", cache({
+  cacheName: "unicode-api:v1-versions",
+  cacheControl: "max-age=345600", // 4 days
+}));
+
+V1_VERSIONS_ROUTER.openapi(LIST_ALL_UNICODE_VERSIONS_ROUTE, async (c) => {
+  try {
+    const response = await fetch("https://www.unicode.org/versions/enumeratedversions.html");
+    if (!response.ok) {
+      return internalServerError(c, {
+        message: "Failed to fetch Unicode versions",
+      });
+    }
+
+    const html = await response.text();
+
+    // find any table that contains Unicode version information
+    const versionPattern = /Unicode \d+\.\d+\.\d+/;
+    const tableMatch = html.match(/<table[^>]*>[\s\S]*?<\/table>/g)?.find((table) =>
+      versionPattern.test(table),
+    );
+
+    if (!tableMatch) {
+      return notFound({
+        message: "Unicode versions table not found",
+      });
+    }
+
+    const draft = await getCurrentDraftVersion().catch(() => null);
+
+    // Get supported versions from metadata
+    const supportedVersions = new Set(Object.keys(UNICODE_VERSION_METADATA));
+
+    const versions: UnicodeVersion[] = [];
+
+    // match any row that contains a cell
+    const rows = tableMatch.match(/<tr>[\s\S]*?<\/tr>/g) || [];
+
+    for (const row of rows) {
+      // look for Unicode version pattern in the row
+      const versionMatch = row.match(new RegExp(`<a[^>]+href="([^"]+)"[^>]*>\\s*(${versionPattern.source})\\s*</a>`));
+      if (!versionMatch) continue;
+
+      const documentationUrl = versionMatch[1];
+      const version = versionMatch[2]!.replace("Unicode ", "");
+
+      // look for a year pattern anywhere in the row
+      const dateMatch = row.match(/<td[^>]*>(\d{4})<\/td>/);
+      if (!dateMatch) continue;
+      const ucdVersion = resolveUCDVersion(version);
+      const ucdUrl = `https://www.unicode.org/Public/${ucdVersion}/${hasUCDFolderPath(ucdVersion) ? "ucd" : ""}`;
+
+      // Determine status based on draft, supported versions, and current implementation
+      let status: "stable" | "draft" | "unsupported" = "stable";
+      if (draft === version) {
+        status = "draft";
+      } else if (!supportedVersions.has(version)) {
+        status = "unsupported";
+      }
+
+      versions.unshift({
+        version,
+        documentationUrl: documentationUrl!,
+        date: dateMatch[1]!,
+        ucdUrl,
+        status,
+        supported: supportedVersions.has(version),
+      });
+    }
+
+    if (draft != null && !versions.some((v) => v.status === "draft")) {
+      versions.push({
+        version: draft,
+        documentationUrl: `https://www.unicode.org/versions/Unicode${draft}/`,
+        date: null,
+        ucdUrl: `https://www.unicode.org/Public/${draft}/ucd`,
+        status: "draft",
+        supported: supportedVersions.has(draft),
+      });
+    }
+
+    if (versions.length === 0) {
+      return notFound(c, {
+        message: "No Unicode versions found",
+      });
+    }
+
+    // sort versions by their major, minor, and patch numbers in from newest to oldest order
+    versions.sort((a, b) => {
+      const [majorA = 0, minorA = 0, patchA = 0] = a.version.split(".").map(Number);
+      const [majorB = 0, minorB = 0, patchB = 0] = b.version.split(".").map(Number);
+
+      if (majorA !== majorB) return majorB - majorA;
+      if (minorA !== minorB) return minorB - minorA;
+      return patchB - patchA;
+    });
+
+    return c.json(versions, 200);
+  } catch (error) {
+    console.error("Error fetching Unicode versions:", error);
+    return internalServerError(c);
+  }
+});
+
+V1_VERSIONS_ROUTER.openapi(GET_UNICODE_MAPPINGS, async (c) => {
+  return c.json(UNICODE_TO_UCD_VERSION_MAPPINGS, 200);
+});
+
+V1_VERSIONS_ROUTER.openapi(GET_UNICODE_VERSION_METADATA, async (c) => {
+  return c.json(UNICODE_VERSION_METADATA, 200);
+});

--- a/apps/api/src/routes/v1_versions.ts
+++ b/apps/api/src/routes/v1_versions.ts
@@ -4,7 +4,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { getCurrentDraftVersion, hasUCDFolderPath, resolveUCDVersion, UNICODE_TO_UCD_VERSION_MAPPINGS, UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
 import { internalServerError, notFound } from "@ucdjs/worker-shared";
 import { cache } from "hono/cache";
-import { GET_SUPPORTED_VERSIONS_ROUTE, GET_UNICODE_MAPPINGS, GET_UNICODE_VERSION_METADATA, LIST_ALL_UNICODE_VERSIONS_ROUTE } from "./v1_versions.openapi";
+import { GET_UNICODE_MAPPINGS, LIST_ALL_UNICODE_VERSIONS_ROUTE } from "./v1_versions.openapi";
 
 export const V1_VERSIONS_ROUTER = new OpenAPIHono<HonoEnv>().basePath("/api/v1/versions");
 
@@ -103,10 +103,3 @@ V1_VERSIONS_ROUTER.openapi(GET_UNICODE_MAPPINGS, async (c) => {
   return c.json(UNICODE_TO_UCD_VERSION_MAPPINGS, 200);
 });
 
-V1_VERSIONS_ROUTER.openapi(GET_UNICODE_VERSION_METADATA, async (c) => {
-  return c.json(UNICODE_VERSION_METADATA, 200);
-});
-
-V1_VERSIONS_ROUTER.openapi(GET_SUPPORTED_VERSIONS_ROUTE, async (c) => {
-  return c.json(UNICODE_VERSION_METADATA, 200);
-});


### PR DESCRIPTION
resolves #100 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced new API endpoints for Unicode version information, including listing all Unicode versions, retrieving Unicode-to-UCD version mappings, and accessing metadata for specific versions.
  * Added comprehensive OpenAPI documentation for the new endpoints, grouped under a "Versions" tag.

* **Documentation**
  * Enhanced API documentation to describe the new "Versions" endpoints and their available data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->