### PR TITLE
fix(api): mark LIST_ALL_UNICODE_VERSIONS_ROUTE and GET_UNICODE_MAPPIN…

### DIFF
--- a/apps/api/src/routes/v1_unicode-versions.openapi.ts
+++ b/apps/api/src/routes/v1_unicode-versions.openapi.ts
@@ -6,6 +6,7 @@ export const LIST_ALL_UNICODE_VERSIONS_ROUTE = createRoute({
   method: "get",
   path: "/",
   tags: ["Misc"],
+  deprecated: true,
   description: "List all Unicode Versions available, including metadata.",
   responses: {
     200: {
@@ -47,6 +48,7 @@ export const GET_UNICODE_MAPPINGS = createRoute({
   method: "get",
   path: "/mappings",
   tags: ["Misc"],
+  deprecated: true,
   description: "List all Unicode Versions mappings",
   responses: {
     200: {


### PR DESCRIPTION
resolve #101 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Marked two API routes related to Unicode versions and mappings as deprecated in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->