### PR TITLE
feat(api): augment RouteConfig for type-safe tags

### DIFF
--- a/apps/api/openapi.d.ts
+++ b/apps/api/openapi.d.ts
@@ -1,0 +1,8 @@
+import type { OpenAPITag } from "./src/openapi";
+
+declare module "@asteasolutions/zod-to-openapi" {
+  // Augment the AsteaSolutions RouteConfig to make tags typesafe.
+  interface RouteConfig {
+    tags?: OpenAPITag[];
+  }
+}

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,6 +27,7 @@
     "zod": "catalog:prod"
   },
   "devDependencies": {
+    "@asteasolutions/zod-to-openapi": "^8.0.0",
     "@cloudflare/vitest-pool-workers": "catalog:testing",
     "@luxass/eslint-config": "catalog:linting",
     "@luxass/spectral-ruleset": "catalog:linting",

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -27,7 +27,7 @@
     "zod": "catalog:prod"
   },
   "devDependencies": {
-    "@asteasolutions/zod-to-openapi": "^8.0.0",
+    "@asteasolutions/zod-to-openapi": "catalog:dev",
     "@cloudflare/vitest-pool-workers": "catalog:testing",
     "@luxass/eslint-config": "catalog:linting",
     "@luxass/spectral-ruleset": "catalog:linting",

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -2,6 +2,18 @@ import type { OpenAPIHono } from "@hono/zod-openapi";
 import { dedent } from "@luxass/utils";
 
 export type OpenAPIObjectConfig = Parameters<OpenAPIHono["getOpenAPI31Document"]>[0];
+export type OpenAPITag
+  = | "Misc"
+    | "Unicode Proxy"
+    | "Files"
+    | "Versions";
+
+export const OPENAPI_TAGS = {
+  MISC: "Misc",
+  UNICODE_PROXY: "Unicode Proxy",
+  FILES: "Files",
+  VERSIONS: "Versions",
+} as const satisfies Record<string, OpenAPITag>;
 
 export function buildOpenApiConfig(version: string, servers: NonNullable<OpenAPIObjectConfig["servers"]>) {
   return {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,27 +6,9 @@ settings:
 
 catalogs:
   dev:
-    '@types/node':
-      specifier: ^22.10.0
-      version: 22.15.2
-    '@types/picomatch':
-      specifier: ^4.0.0
-      version: 4.0.0
-    '@types/yargs-parser':
-      specifier: ^21.0.3
-      version: 21.0.3
     nanotar:
       specifier: ^0.2.0
       version: 0.2.0
-    openapi-typescript:
-      specifier: ^7.8.0
-      version: 7.8.0
-    publint:
-      specifier: ^0.3.12
-      version: 0.3.12
-    tsdown:
-      specifier: ^0.12.9
-      version: 0.12.9
     tsx:
       specifier: ^4.20.3
       version: 4.20.3
@@ -49,59 +31,16 @@ catalogs:
     eslint-plugin-format:
       specifier: ^1.0.1
       version: 1.0.1
-  monorepo:
-    '@changesets/changelog-github':
-      specifier: ^0.5.1
-      version: 0.5.1
-    '@changesets/cli':
-      specifier: ^2.29.5
-      version: 2.29.5
-    turbo:
-      specifier: ^2.5.5
-      version: 2.5.5
   prod:
-    '@ai-sdk/openai':
-      specifier: ^1.3.22
-      version: 1.3.22
-    '@luxass/unicode-utils':
-      specifier: ^0.9.0
-      version: 0.9.0
     '@luxass/unicode-utils-new':
       specifier: npm:@luxass/unicode-utils@0.12.0-beta.9
       version: 0.12.0-beta.9
     '@luxass/utils':
       specifier: ^2.6.0
       version: 2.6.0
-    ai:
-      specifier: ^4.3.16
-      version: 4.3.16
     apache-autoindex-parse:
       specifier: ^2.3.0
       version: 2.3.0
-    defu:
-      specifier: ^6.1.4
-      version: 6.1.4
-    farver:
-      specifier: ^0.4.2
-      version: 0.4.2
-    knitwork:
-      specifier: ^1.2.0
-      version: 1.2.0
-    memfs:
-      specifier: ^4.17.2
-      version: 4.17.2
-    openapi-fetch:
-      specifier: ^0.14.0
-      version: 0.14.0
-    p-limit:
-      specifier: ^6.2.0
-      version: 6.2.0
-    picomatch:
-      specifier: ^4.0.2
-      version: 4.0.2
-    yargs-parser:
-      specifier: ^22.0.0
-      version: 22.0.0
     zod:
       specifier: ^4.0.5
       version: 4.0.5
@@ -109,21 +48,9 @@ catalogs:
     '@cloudflare/vitest-pool-workers':
       specifier: ^0.8.55
       version: 0.8.55
-    '@vitest/coverage-istanbul':
-      specifier: ^3.2.4
-      version: 3.2.4
-    '@vitest/ui':
-      specifier: ^3.2.4
-      version: 3.2.4
-    msw:
-      specifier: ^2.10.4
-      version: 2.10.4
     vitest:
       specifier: ^3.2.4
       version: 3.2.4
-    vitest-testdirs:
-      specifier: ^4.0.1
-      version: 4.0.1
   workers:
     '@hono/zod-openapi':
       specifier: ^1.0.2
@@ -203,6 +130,9 @@ importers:
         specifier: catalog:prod
         version: 4.0.5
     devDependencies:
+      '@asteasolutions/zod-to-openapi':
+        specifier: ^8.0.0
+        version: 8.0.0(zod@4.0.5)
       '@cloudflare/vitest-pool-workers':
         specifier: catalog:testing
         version: 0.8.55(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4)
@@ -5343,7 +5273,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5365,7 +5295,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -6286,7 +6216,7 @@ snapshots:
       '@typescript-eslint/types': 8.37.0
       '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.37.0
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       eslint: 9.31.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -6296,7 +6226,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.8.3)
       '@typescript-eslint/types': 8.35.1
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -6305,7 +6235,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.37.0(typescript@5.8.3)
       '@typescript-eslint/types': 8.37.0
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -6333,7 +6263,7 @@ snapshots:
       '@typescript-eslint/types': 8.37.0
       '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.8.3)
       '@typescript-eslint/utils': 8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       eslint: 9.31.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -6350,7 +6280,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.8.3)
       '@typescript-eslint/types': 8.35.1
       '@typescript-eslint/visitor-keys': 8.35.1
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -6366,7 +6296,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.37.0(typescript@5.8.3)
       '@typescript-eslint/types': 8.37.0
       '@typescript-eslint/visitor-keys': 8.37.0
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -6451,14 +6381,14 @@ snapshots:
       msw: 2.10.4(@types/node@22.15.2)(typescript@5.8.3)
       vite: 6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
-  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.0.7)(typescript@5.8.3))(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.0.7)(typescript@5.8.3))(vite@6.3.3(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.10.4(@types/node@24.0.7)(typescript@5.8.3)
-      vite: 6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 6.3.3(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6489,7 +6419,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.2)(@vitest/ui@3.2.4)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.4(@types/node@22.15.2)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(@vitest/ui@3.2.4)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.0.7)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -6839,6 +6769,10 @@ snapshots:
 
   dataloader@1.4.0: {}
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   debug@4.4.1(supports-color@10.0.0):
     dependencies:
       ms: 2.1.3
@@ -7121,7 +7055,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.52.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       escape-string-regexp: 4.0.0
       eslint: 9.31.0(jiti@2.4.2)
       espree: 10.4.0
@@ -7199,7 +7133,7 @@ snapshots:
 
   eslint-plugin-toml@0.12.0(eslint@9.31.0(jiti@2.4.2)):
     dependencies:
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       eslint: 9.31.0(jiti@2.4.2)
       eslint-compat-utils: 0.6.5(eslint@9.31.0(jiti@2.4.2))
       lodash: 4.17.21
@@ -7249,7 +7183,7 @@ snapshots:
 
   eslint-plugin-yml@1.18.0(eslint@9.31.0(jiti@2.4.2)):
     dependencies:
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       escape-string-regexp: 4.0.0
       eslint: 9.31.0(jiti@2.4.2)
       eslint-compat-utils: 0.6.5(eslint@9.31.0(jiti@2.4.2))
@@ -7290,7 +7224,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -8320,7 +8254,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       decode-named-character-reference: 1.1.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -9404,7 +9338,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.0.2(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
@@ -9542,14 +9476,14 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.0.7)(typescript@5.8.3))(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.0.7)(typescript@5.8.3))(vite@6.3.3(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3
@@ -9583,7 +9517,7 @@ snapshots:
 
   vue-eslint-parser@10.2.0(eslint@9.31.0(jiti@2.4.2)):
     dependencies:
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.1
       eslint: 9.31.0(jiti@2.4.2)
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,30 @@ settings:
 
 catalogs:
   dev:
+    '@asteasolutions/zod-to-openapi':
+      specifier: ^8.0.0
+      version: 8.0.0
+    '@types/node':
+      specifier: ^22.10.0
+      version: 22.15.2
+    '@types/picomatch':
+      specifier: ^4.0.0
+      version: 4.0.0
+    '@types/yargs-parser':
+      specifier: ^21.0.3
+      version: 21.0.3
     nanotar:
       specifier: ^0.2.0
       version: 0.2.0
+    openapi-typescript:
+      specifier: ^7.8.0
+      version: 7.8.0
+    publint:
+      specifier: ^0.3.12
+      version: 0.3.12
+    tsdown:
+      specifier: ^0.12.9
+      version: 0.12.9
     tsx:
       specifier: ^4.20.3
       version: 4.20.3
@@ -31,16 +52,59 @@ catalogs:
     eslint-plugin-format:
       specifier: ^1.0.1
       version: 1.0.1
+  monorepo:
+    '@changesets/changelog-github':
+      specifier: ^0.5.1
+      version: 0.5.1
+    '@changesets/cli':
+      specifier: ^2.29.5
+      version: 2.29.5
+    turbo:
+      specifier: ^2.5.5
+      version: 2.5.5
   prod:
+    '@ai-sdk/openai':
+      specifier: ^1.3.22
+      version: 1.3.22
+    '@luxass/unicode-utils':
+      specifier: ^0.9.0
+      version: 0.9.0
     '@luxass/unicode-utils-new':
       specifier: npm:@luxass/unicode-utils@0.12.0-beta.9
       version: 0.12.0-beta.9
     '@luxass/utils':
       specifier: ^2.6.0
       version: 2.6.0
+    ai:
+      specifier: ^4.3.16
+      version: 4.3.16
     apache-autoindex-parse:
       specifier: ^2.3.0
       version: 2.3.0
+    defu:
+      specifier: ^6.1.4
+      version: 6.1.4
+    farver:
+      specifier: ^0.4.2
+      version: 0.4.2
+    knitwork:
+      specifier: ^1.2.0
+      version: 1.2.0
+    memfs:
+      specifier: ^4.17.2
+      version: 4.17.2
+    openapi-fetch:
+      specifier: ^0.14.0
+      version: 0.14.0
+    p-limit:
+      specifier: ^6.2.0
+      version: 6.2.0
+    picomatch:
+      specifier: ^4.0.2
+      version: 4.0.2
+    yargs-parser:
+      specifier: ^22.0.0
+      version: 22.0.0
     zod:
       specifier: ^4.0.5
       version: 4.0.5
@@ -48,9 +112,21 @@ catalogs:
     '@cloudflare/vitest-pool-workers':
       specifier: ^0.8.55
       version: 0.8.55
+    '@vitest/coverage-istanbul':
+      specifier: ^3.2.4
+      version: 3.2.4
+    '@vitest/ui':
+      specifier: ^3.2.4
+      version: 3.2.4
+    msw:
+      specifier: ^2.10.4
+      version: 2.10.4
     vitest:
       specifier: ^3.2.4
       version: 3.2.4
+    vitest-testdirs:
+      specifier: ^4.0.1
+      version: 4.0.1
   workers:
     '@hono/zod-openapi':
       specifier: ^1.0.2
@@ -131,7 +207,7 @@ importers:
         version: 4.0.5
     devDependencies:
       '@asteasolutions/zod-to-openapi':
-        specifier: ^8.0.0
+        specifier: catalog:dev
         version: 8.0.0(zod@4.0.5)
       '@cloudflare/vitest-pool-workers':
         specifier: catalog:testing
@@ -642,11 +718,6 @@ packages:
     resolution: {integrity: sha512-muE8Tt8M22638HU31A3CgfSUciwz1fhATfoVai05aPXGor//CdWDCbnlY1yvBPo07njuVOCNGCSp/GTt12lIug==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/parser@7.27.5':
-    resolution: {integrity: sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-
   '@babel/parser@7.27.7':
     resolution: {integrity: sha512-qnzXzDXdr/po3bOTbTIQZ7+TxNKxpkN5IifVLXS+r7qwynkZfPyjZfE7hCXbo7IoO9TNcSyibgONsf2HauUd3Q==}
     engines: {node: '>=6.0.0'}
@@ -662,10 +733,6 @@ packages:
 
   '@babel/traverse@7.27.7':
     resolution: {integrity: sha512-X6ZlfR/O/s5EQ/SnUSLzr+6kGnkg8HXGMzpgsMsrJVcfDtH1vIp6ctCN4eZ1LS5c0+te5Cb6Y514fASjMRJ1nw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/types@7.27.3':
-    resolution: {integrity: sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.27.7':
@@ -4881,10 +4948,6 @@ snapshots:
       '@babel/template': 7.27.2
       '@babel/types': 7.27.7
 
-  '@babel/parser@7.27.5':
-    dependencies:
-      '@babel/types': 7.27.3
-
   '@babel/parser@7.27.7':
     dependencies:
       '@babel/types': 7.27.7
@@ -4910,11 +4973,6 @@ snapshots:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-
-  '@babel/types@7.27.3':
-    dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.27.1
 
   '@babel/types@7.27.7':
     dependencies:
@@ -5273,7 +5331,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -5295,7 +5353,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -6216,7 +6274,7 @@ snapshots:
       '@typescript-eslint/types': 8.37.0
       '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.37.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       eslint: 9.31.0(jiti@2.4.2)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -6226,7 +6284,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.8.3)
       '@typescript-eslint/types': 8.35.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -6235,7 +6293,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.37.0(typescript@5.8.3)
       '@typescript-eslint/types': 8.37.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -6263,7 +6321,7 @@ snapshots:
       '@typescript-eslint/types': 8.37.0
       '@typescript-eslint/typescript-estree': 8.37.0(typescript@5.8.3)
       '@typescript-eslint/utils': 8.37.0(eslint@9.31.0(jiti@2.4.2))(typescript@5.8.3)
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       eslint: 9.31.0(jiti@2.4.2)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -6280,7 +6338,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.8.3)
       '@typescript-eslint/types': 8.35.1
       '@typescript-eslint/visitor-keys': 8.35.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -6296,7 +6354,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.37.0(typescript@5.8.3)
       '@typescript-eslint/types': 8.37.0
       '@typescript-eslint/visitor-keys': 8.37.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -6381,14 +6439,14 @@ snapshots:
       msw: 2.10.4(@types/node@22.15.2)(typescript@5.8.3)
       vite: 6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
-  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.0.7)(typescript@5.8.3))(vite@6.3.3(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
+  '@vitest/mocker@3.2.4(msw@2.10.4(@types/node@24.0.7)(typescript@5.8.3))(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
       msw: 2.10.4(@types/node@24.0.7)(typescript@5.8.3)
-      vite: 6.3.3(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vite: 6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6419,7 +6477,7 @@ snapshots:
       sirv: 3.0.1
       tinyglobby: 0.2.14
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.7)(@vitest/ui@3.2.4)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.4(@types/node@24.0.7)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.15.2)(@vitest/ui@3.2.4)(jiti@2.4.2)(lightningcss@1.30.1)(msw@2.10.4(@types/node@22.15.2)(typescript@5.8.3))(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -6769,10 +6827,6 @@ snapshots:
 
   dataloader@1.4.0: {}
 
-  debug@4.4.1:
-    dependencies:
-      ms: 2.1.3
-
   debug@4.4.1(supports-color@10.0.0):
     dependencies:
       ms: 2.1.3
@@ -7055,7 +7109,7 @@ snapshots:
       '@es-joy/jsdoccomment': 0.52.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       escape-string-regexp: 4.0.0
       eslint: 9.31.0(jiti@2.4.2)
       espree: 10.4.0
@@ -7133,7 +7187,7 @@ snapshots:
 
   eslint-plugin-toml@0.12.0(eslint@9.31.0(jiti@2.4.2)):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       eslint: 9.31.0(jiti@2.4.2)
       eslint-compat-utils: 0.6.5(eslint@9.31.0(jiti@2.4.2))
       lodash: 4.17.21
@@ -7183,7 +7237,7 @@ snapshots:
 
   eslint-plugin-yml@1.18.0(eslint@9.31.0(jiti@2.4.2)):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       escape-string-regexp: 4.0.0
       eslint: 9.31.0(jiti@2.4.2)
       eslint-compat-utils: 0.6.5(eslint@9.31.0(jiti@2.4.2))
@@ -7224,7 +7278,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -7734,7 +7788,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.27.7
-      '@babel/parser': 7.27.5
+      '@babel/parser': 7.27.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.2
@@ -7939,8 +7993,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.27.5
-      '@babel/types': 7.27.3
+      '@babel/parser': 7.27.7
+      '@babel/types': 7.27.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -8254,7 +8308,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       decode-named-character-reference: 1.1.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -9338,7 +9392,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.0.2(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0)
@@ -9476,14 +9530,14 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.0.7)(typescript@5.8.3))(vite@6.3.3(@types/node@24.0.7)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
+      '@vitest/mocker': 3.2.4(msw@2.10.4(@types/node@24.0.7)(typescript@5.8.3))(vite@6.3.3(@types/node@22.15.2)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(tsx@4.20.3)(yaml@2.8.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       expect-type: 1.2.1
       magic-string: 0.30.17
       pathe: 2.0.3
@@ -9517,7 +9571,7 @@ snapshots:
 
   vue-eslint-parser@10.2.0(eslint@9.31.0(jiti@2.4.2)):
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@10.0.0)
       eslint: 9.31.0(jiti@2.4.2)
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -58,6 +58,7 @@ catalogs:
     nanotar: ^0.2.0
     openapi-typescript: ^7.8.0
     tsx: ^4.20.3
+    "@asteasolutions/zod-to-openapi": ^8.0.0
 
   workers:
     wrangler: ^4.25.0


### PR DESCRIPTION
resolve #119 

* Added `tags` property to `RouteConfig` interface in the `@asteasolutions/zod-to-openapi` module.
* Introduced `OpenAPITag` type and `OPENAPI_TAGS` constant in `openapi.ts` for better type safety.
* Updated `package.json` to include `@asteasolutions/zod-to-openapi` as a dependency.
