### PR TITLE
fix(worker-shared): remove unused path property from ApiErrorSchema

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -75,26 +75,21 @@ app.doc31("/openapi.json", (c) => {
 });
 
 app.onError(async (err, c) => {
+  console.warn("Error processing request:", c.req.path);
   console.error(err);
-  const url = new URL(c.req.url);
   if (err instanceof HTTPException) {
     return customError({
-      path: url.pathname,
       status: err.status,
       message: err.message,
     });
   }
 
-  return internalServerError({
-    path: url.pathname,
-  });
+  return internalServerError();
 });
 
 app.notFound(async (c) => {
-  const url = new URL(c.req.url);
-  return notFound({
-    path: url.pathname,
-  });
+  console.warn("Not Found:", c.req.path);
+  return notFound();
 });
 
 export const getOpenAPI31Document = app.getOpenAPI31Document;

--- a/apps/api/test/index.test.ts
+++ b/apps/api/test/index.test.ts
@@ -16,7 +16,6 @@ it("respond with a 404", async () => {
   expect(await response.json()).toEqual({
     message: "Not found",
     status: 404,
-    path: "/not-found",
     timestamp: expect.any(String),
   });
 });

--- a/apps/proxy/src/index.ts
+++ b/apps/proxy/src/index.ts
@@ -176,26 +176,21 @@ app.get(
 );
 
 app.onError(async (err, c) => {
+  console.warn("Error processing request:", c.req.path);
   console.error(err);
-  const url = new URL(c.req.url);
   if (err instanceof HTTPException) {
     return customError({
-      path: url.pathname,
       status: err.status,
       message: err.message,
     });
   }
 
-  return internalServerError({
-    path: url.pathname,
-  });
+  return internalServerError();
 });
 
 app.notFound(async (c) => {
-  const url = new URL(c.req.url);
-  return notFound({
-    path: url.pathname,
-  });
+  console.warn("Not Found:", c.req.path);
+  return notFound();
 });
 
 export default class UnicodeProxy extends WorkerEntrypoint<CloudflareBindings> {

--- a/apps/proxy/test/index.test.ts
+++ b/apps/proxy/test/index.test.ts
@@ -16,7 +16,6 @@ it("respond with a 404", async () => {
   expect(await response.json()).toEqual({
     message: "Not Found",
     status: 404,
-    path: "/not-found",
     timestamp: expect.any(String),
   });
 });
@@ -83,7 +82,6 @@ it("should handle 404 for non-existent paths", async () => {
   expect(await response.json()).toEqual({
     message: "Not Found",
     status: 404,
-    path: "/not-a-real-path",
     timestamp: expect.any(String),
   });
 });

--- a/packages/fetch/test/index.test.ts
+++ b/packages/fetch/test/index.test.ts
@@ -100,7 +100,6 @@ describe("unicode API Client", () => {
     describe("error handling", () => {
       it("should handle 404 Not Found errors", async () => {
         const errorResponse: ApiError = {
-          path: "/api/v1/unicode-versions",
           message: "Resource not found",
           status: 404,
           timestamp: "2025-06-26T12:00:00Z",
@@ -124,7 +123,6 @@ describe("unicode API Client", () => {
 
       it("should handle 500 Internal Server Error", async () => {
         const errorResponse: ApiError = {
-          path: "/api/v1/unicode-versions",
           message: "Internal server error occurred",
           status: 500,
           timestamp: "2025-06-26T12:00:00Z",

--- a/packages/worker-shared/src/errors.ts
+++ b/packages/worker-shared/src/errors.ts
@@ -20,7 +20,7 @@ export interface ResponseOptions {
  * Creates a standardized 400 Bad Request HTTP response with JSON error details.
  *
  * @param {Context | ResponseOptions} contextOrOptions - Hono context or configuration options
- * @param {Omit<ResponseOptions, 'path'>?} options - Configuration options when context is provided
+ * @param {ResponseOptions?} options - Configuration options when context is provided
  * @returns {Response} A Response object with 400 status and JSON error body
  *
  * @example
@@ -30,17 +30,16 @@ export interface ResponseOptions {
  * // Basic usage (legacy)
  * return badRequest();
  *
- * // With custom message and path (legacy)
+ * // With custom message
  * return badRequest({
  *   message: "Invalid request parameters",
- *   path: "/api/users"
  * });
  *
  * // With Hono context (new)
  * return badRequest(c, { message: "Invalid request parameters" });
  * ```
  */
-export function badRequest(contextOrOptions: Context | ResponseOptions = {}, options: Omit<ResponseOptions, "path"> = {}): Response & TypedResponse<ApiError, 400, "json"> {
+export function badRequest(contextOrOptions: Context | ResponseOptions = {}, options: ResponseOptions = {}): Response & TypedResponse<ApiError, 400, "json"> {
   let finalOptions: ResponseOptions;
 
   if ("req" in contextOrOptions) {
@@ -67,7 +66,7 @@ export function badRequest(contextOrOptions: Context | ResponseOptions = {}, opt
  * Creates a standardized 403 Forbidden HTTP response with JSON error details.
  *
  * @param {Context | ResponseOptions} contextOrOptions - Hono context or configuration options
- * @param {Omit<ResponseOptions, 'path'>?} options - Configuration options when context is provided
+ * @param {ResponseOptions?} options - Configuration options when context is provided
  * @returns {Response} A Response object with 403 status and JSON error body
  *
  * @example
@@ -77,17 +76,16 @@ export function badRequest(contextOrOptions: Context | ResponseOptions = {}, opt
  * // Basic usage (legacy)
  * return forbidden();
  *
- * // With custom message and path (legacy)
+ * // With custom message (legacy)
  * return forbidden({
- *   message: "Access denied to this resource",
- *   path: "/api/admin/users"
+ *   message: "Access denied to this resource"
  * });
  *
  * // With Hono context (new)
  * return forbidden(c, { message: "Access denied to this resource" });
  * ```
  */
-export function forbidden(contextOrOptions: Context | ResponseOptions = {}, options: Omit<ResponseOptions, "path"> = {}): Response & TypedResponse<ApiError, 403, "json"> {
+export function forbidden(contextOrOptions: Context | ResponseOptions = {}, options: ResponseOptions = {}): Response & TypedResponse<ApiError, 403, "json"> {
   let finalOptions: ResponseOptions;
 
   if ("req" in contextOrOptions) {
@@ -114,7 +112,7 @@ export function forbidden(contextOrOptions: Context | ResponseOptions = {}, opti
  * Creates a standardized 404 Not Found HTTP response with JSON error details.
  *
  * @param {Context | ResponseOptions} contextOrOptions - Hono context or configuration options
- * @param {Omit<ResponseOptions, 'path'>?} options - Configuration options when context is provided
+ * @param {ResponseOptions?} options - Configuration options when context is provided
  * @returns {Response} A Response object with 404 status and JSON error body
  *
  * @example
@@ -124,17 +122,16 @@ export function forbidden(contextOrOptions: Context | ResponseOptions = {}, opti
  * // Basic usage (legacy)
  * return notFound();
  *
- * // With custom message and path (legacy)
+ * // With custom message (legacy)
  * return notFound({
- *   message: "User not found",
- *   path: "/api/users/123"
+ *   message: "User not found"
  * });
  *
  * // With Hono context (new)
  * return notFound(c, { message: "User not found" });
  * ```
  */
-export function notFound(contextOrOptions: Context | ResponseOptions = {}, options: Omit<ResponseOptions, "path"> = {}): Response & TypedResponse<ApiError, 404, "json"> {
+export function notFound(contextOrOptions: Context | ResponseOptions = {}, options: ResponseOptions = {}): Response & TypedResponse<ApiError, 404, "json"> {
   let finalOptions: ResponseOptions;
 
   if ("req" in contextOrOptions) {
@@ -161,7 +158,7 @@ export function notFound(contextOrOptions: Context | ResponseOptions = {}, optio
  * Creates a standardized 500 Internal Server Error HTTP response with JSON error details.
  *
  * @param {Context | ResponseOptions} contextOrOptions - Hono context or configuration options
- * @param {Omit<ResponseOptions, 'path'>?} options - Configuration options when context is provided
+ * @param {ResponseOptions?} options - Configuration options when context is provided
  * @returns {Response} A Response object with 500 status and JSON error body
  *
  * @example
@@ -171,17 +168,16 @@ export function notFound(contextOrOptions: Context | ResponseOptions = {}, optio
  * // Basic usage (legacy)
  * return internalServerError();
  *
- * // With custom message and path (legacy)
+ * // With custom message (legacy)
  * return internalServerError({
- *   message: "Database connection failed",
- *   path: "/api/users"
+ *   message: "Database connection failed"
  * });
  *
  * // With Hono context (new)
  * return internalServerError(c, { message: "Database connection failed" });
  * ```
  */
-export function internalServerError(contextOrOptions: Context | ResponseOptions = {}, options: Omit<ResponseOptions, "path"> = {}): Response & TypedResponse<ApiError, 500, "json"> {
+export function internalServerError(contextOrOptions: Context | ResponseOptions = {}, options: ResponseOptions = {}): Response & TypedResponse<ApiError, 500, "json"> {
   let finalOptions: ResponseOptions;
 
   if ("req" in contextOrOptions) {
@@ -218,7 +214,7 @@ export type CustomResponseOptions = Omit<Required<ResponseOptions>, "headers"> &
   status: number;
 };
 
-export type CustomResponseOptionsWithContext = Omit<CustomResponseOptions, "path"> & {
+export type CustomResponseOptionsWithContext = CustomResponseOptions & {
   /**
    * Custom headers to include in the response.
    * This can be used to set headers like `Content-Type`, `Cache-Control`, etc.
@@ -248,14 +244,12 @@ export type CustomResponseOptionsWithContext = Omit<CustomResponseOptions, "path
  * return customError({
  *   status: 422,
  *   message: "Validation failed",
- *   path: "/api/users"
  * });
  *
  * // Custom 429 Too Many Requests error with headers (legacy)
  * return customError({
  *   status: 429,
  *   message: "Rate limit exceeded",
- *   path: "/api/data",
  *   headers: {
  *     "Retry-After": "3600"
  *   }

--- a/packages/worker-shared/src/errors.ts
+++ b/packages/worker-shared/src/errors.ts
@@ -9,11 +9,6 @@ export interface ResponseOptions {
   message?: string;
 
   /**
-   * The path of the request that resulted in the error.
-   */
-  path?: string;
-
-  /**
    * Additional headers to include in the response.
    * This can be used to set custom headers like `Content-Type`, `Cache-Control`,
    * or any other headers that might be relevant to the response.
@@ -49,19 +44,13 @@ export function badRequest(contextOrOptions: Context | ResponseOptions = {}, opt
   let finalOptions: ResponseOptions;
 
   if ("req" in contextOrOptions) {
-    // It's a Hono context
-    const url = new URL(contextOrOptions.req.url);
-    finalOptions = {
-      path: url.pathname,
-      ...options,
-    };
+    finalOptions = options;
   } else {
     // It's options (legacy usage)
     finalOptions = contextOrOptions;
   }
 
   return Response.json({
-    path: finalOptions.path || "unknown",
     message: finalOptions.message || "Bad request",
     status: 400,
     timestamp: new Date().toISOString(),
@@ -102,19 +91,13 @@ export function forbidden(contextOrOptions: Context | ResponseOptions = {}, opti
   let finalOptions: ResponseOptions;
 
   if ("req" in contextOrOptions) {
-    // It's a Hono context
-    const url = new URL(contextOrOptions.req.url);
-    finalOptions = {
-      path: url.pathname,
-      ...options,
-    };
+    finalOptions = options;
   } else {
     // It's options (legacy usage)
     finalOptions = contextOrOptions;
   }
 
   return Response.json({
-    path: finalOptions.path || "unknown",
     message: finalOptions.message || "Forbidden",
     status: 403,
     timestamp: new Date().toISOString(),
@@ -155,19 +138,13 @@ export function notFound(contextOrOptions: Context | ResponseOptions = {}, optio
   let finalOptions: ResponseOptions;
 
   if ("req" in contextOrOptions) {
-    // It's a Hono context
-    const url = new URL(contextOrOptions.req.url);
-    finalOptions = {
-      path: url.pathname,
-      ...options,
-    };
+    finalOptions = options;
   } else {
     // It's options (legacy usage)
     finalOptions = contextOrOptions;
   }
 
   return Response.json({
-    path: finalOptions.path || "unknown",
     message: finalOptions.message || "Not found",
     status: 404,
     timestamp: new Date().toISOString(),
@@ -208,19 +185,13 @@ export function internalServerError(contextOrOptions: Context | ResponseOptions 
   let finalOptions: ResponseOptions;
 
   if ("req" in contextOrOptions) {
-    // It's a Hono context
-    const url = new URL(contextOrOptions.req.url);
-    finalOptions = {
-      path: url.pathname,
-      ...options,
-    };
+    finalOptions = options;
   } else {
     // It's options (legacy usage)
     finalOptions = contextOrOptions;
   }
 
   return Response.json({
-    path: finalOptions.path || "unknown",
     message: finalOptions.message || "Internal server error",
     status: 500,
     timestamp: new Date().toISOString(),
@@ -305,18 +276,13 @@ export function customError(contextOrOptions: Context | CustomResponseOptions, o
     if (!options) {
       throw new Error("Options parameter is required when using Hono context");
     }
-    const url = new URL(contextOrOptions.req.url);
-    finalOptions = {
-      path: url.pathname,
-      ...options,
-    };
+    finalOptions = options;
   } else {
     // It's options (legacy usage)
     finalOptions = contextOrOptions;
   }
 
   return Response.json({
-    path: finalOptions.path,
     message: finalOptions.message,
     status: finalOptions.status,
     timestamp: new Date().toISOString(),

--- a/packages/worker-shared/src/schemas.ts
+++ b/packages/worker-shared/src/schemas.ts
@@ -1,9 +1,6 @@
 import { z } from "@hono/zod-openapi";
 
 export const ApiErrorSchema = z.object({
-  path: z.string().openapi({
-    description: "The path of the request",
-  }),
   message: z.string().openapi({
     description: "The error message",
   }),

--- a/packages/worker-shared/test/errors.test.ts
+++ b/packages/worker-shared/test/errors.test.ts
@@ -29,7 +29,6 @@ describe("badRequest", () => {
     expect(response.status).toBe(400);
     expect(response.headers.get("Content-Type")).toBe("application/json");
     expect(body).toEqual({
-      path: "unknown",
       message: "Bad request",
       status: 400,
       timestamp: "2023-06-15T10:30:00.000Z",
@@ -55,7 +54,6 @@ describe("badRequest", () => {
   it("should return 400 response with all options", async () => {
     const options = {
       message: "Validation failed",
-      path: "/api/validate",
       headers: { "X-Request-ID": "123456" },
     };
     const response = badRequest(options);
@@ -64,7 +62,6 @@ describe("badRequest", () => {
     expect(response.status).toBe(400);
     expect(response.headers.get("X-Request-ID")).toBe("123456");
     expect(body).toEqual({
-      path: "/api/validate",
       message: "Validation failed",
       status: 400,
       timestamp: "2023-06-15T10:30:00.000Z",
@@ -78,7 +75,6 @@ describe("badRequest", () => {
 
     expect(response.status).toBe(400);
     expect(body).toEqual({
-      path: "/api/users",
       message: "Bad request",
       status: 400,
       timestamp: "2023-06-15T10:30:00.000Z",
@@ -92,7 +88,6 @@ describe("badRequest", () => {
 
     expect(response.status).toBe(400);
     expect(body).toEqual({
-      path: "/api/users/123",
       message: "Invalid user ID",
       status: 400,
       timestamp: "2023-06-15T10:30:00.000Z",
@@ -109,7 +104,6 @@ describe("badRequest", () => {
 
     expect(response.status).toBe(400);
     expect(response.headers.get("X-Request-ID")).toBe("abc123");
-    expect(body.path).toBe("/api/validate");
     expect(body.message).toBe("Validation failed");
   });
 });
@@ -122,7 +116,6 @@ describe("forbidden", () => {
     expect(response.status).toBe(403);
     expect(response.headers.get("Content-Type")).toBe("application/json");
     expect(body).toEqual({
-      path: "unknown",
       message: "Forbidden",
       status: 403,
       timestamp: "2023-06-15T10:30:00.000Z",
@@ -151,7 +144,6 @@ describe("forbidden", () => {
 
     expect(response.status).toBe(403);
     expect(body).toEqual({
-      path: "/api/admin",
       message: "Forbidden",
       status: 403,
       timestamp: "2023-06-15T10:30:00.000Z",
@@ -164,7 +156,6 @@ describe("forbidden", () => {
     const body = await response.json();
 
     expect(response.status).toBe(403);
-    expect(body.path).toBe("/api/admin/users");
     expect(body.message).toBe("Access denied to admin area");
   });
 });
@@ -177,7 +168,6 @@ describe("notFound", () => {
     expect(response.status).toBe(404);
     expect(response.headers.get("Content-Type")).toBe("application/json");
     expect(body).toEqual({
-      path: "unknown",
       message: "Not found",
       status: 404,
       timestamp: "2023-06-15T10:30:00.000Z",
@@ -195,7 +185,6 @@ describe("notFound", () => {
   it("should return 404 response with all options", async () => {
     const options = {
       message: "Resource not found",
-      path: "/api/resources/abc123",
       headers: { "Cache-Control": "no-cache" },
     };
     const response = notFound(options);
@@ -204,7 +193,6 @@ describe("notFound", () => {
     expect(response.status).toBe(404);
     expect(response.headers.get("Cache-Control")).toBe("no-cache");
     expect(body.message).toBe("Resource not found");
-    expect(body.path).toBe("/api/resources/abc123");
   });
 
   it("should return 404 response with Hono context", async () => {
@@ -214,7 +202,6 @@ describe("notFound", () => {
 
     expect(response.status).toBe(404);
     expect(body).toEqual({
-      path: "/api/users/999",
       message: "Not found",
       status: 404,
       timestamp: "2023-06-15T10:30:00.000Z",
@@ -227,7 +214,6 @@ describe("notFound", () => {
     const body = await response.json();
 
     expect(response.status).toBe(404);
-    expect(body.path).toBe("/api/products/abc123");
     expect(body.message).toBe("Product not found");
   });
 });
@@ -240,7 +226,6 @@ describe("internalServerError", () => {
     expect(response.status).toBe(500);
     expect(response.headers.get("Content-Type")).toBe("application/json");
     expect(body).toEqual({
-      path: "unknown",
       message: "Internal server error",
       status: 500,
       timestamp: "2023-06-15T10:30:00.000Z",
@@ -269,7 +254,6 @@ describe("internalServerError", () => {
 
     expect(response.status).toBe(500);
     expect(body).toEqual({
-      path: "/api/database",
       message: "Internal server error",
       status: 500,
       timestamp: "2023-06-15T10:30:00.000Z",
@@ -282,7 +266,6 @@ describe("internalServerError", () => {
     const body = await response.json();
 
     expect(response.status).toBe(500);
-    expect(body.path).toBe("/api/users/sync");
     expect(body.message).toBe("Database sync failed");
   });
 });
@@ -329,7 +312,6 @@ describe("custom error handling", () => {
     const customErrorOptions = {
       status: 418,
       message: "I'm a teapot",
-      path: "/api/teapot",
       headers: { "X-Teapot": "true" },
     };
 
@@ -338,7 +320,6 @@ describe("custom error handling", () => {
 
     expect(response.status).toBe(418);
     expect(body.message).toBe("I'm a teapot");
-    expect(body.path).toBe("/api/teapot");
     expect(response.headers.get("X-Teapot")).toBe("true");
   });
 
@@ -346,7 +327,6 @@ describe("custom error handling", () => {
     const customErrorOptions = {
       status: 422,
       message: "Unprocessable Entity",
-      path: "/api/resources/abc123",
       headers: { "X-Error-Detail": "Invalid input" },
     };
 
@@ -355,7 +335,6 @@ describe("custom error handling", () => {
 
     expect(response.status).toBe(422);
     expect(body.message).toBe("Unprocessable Entity");
-    expect(body.path).toBe("/api/resources/abc123");
     expect(response.headers.get("X-Error-Detail")).toBe("Invalid input");
   });
 
@@ -369,7 +348,6 @@ describe("custom error handling", () => {
 
     expect(response.status).toBe(418);
     expect(body).toEqual({
-      path: "/api/teapot",
       message: "I'm a teapot",
       status: 418,
       timestamp: "2023-06-15T10:30:00.000Z",
@@ -386,7 +364,6 @@ describe("custom error handling", () => {
     const body = await response.json();
 
     expect(response.status).toBe(429);
-    expect(body.path).toBe("/api/rate-limit");
     expect(body.message).toBe("Too Many Requests");
     expect(response.headers.get("Retry-After")).toBe("3600");
   });
@@ -406,33 +383,7 @@ describe("hono context integration", () => {
     const response = badRequest(context, { message: "Invalid query parameters" });
     const body = await response.json();
 
-    expect(body.path).toBe("/api/users");
     expect(body.message).toBe("Invalid query parameters");
-  });
-
-  it("should handle URLs with fragments", async () => {
-    const context = createMockContext("https://example.com/api/docs#section-1");
-    const response = notFound(context);
-    const body = await response.json();
-
-    expect(body.path).toBe("/api/docs");
-  });
-
-  it("should handle complex nested paths", async () => {
-    const context = createMockContext("https://example.com/api/v1/users/123/posts/456/comments");
-    const response = forbidden(context, { message: "Access denied to nested resource" });
-    const body = await response.json();
-
-    expect(body.path).toBe("/api/v1/users/123/posts/456/comments");
-    expect(body.message).toBe("Access denied to nested resource");
-  });
-
-  it("should handle root path", async () => {
-    const context = createMockContext("https://example.com/");
-    const response = internalServerError(context);
-    const body = await response.json();
-
-    expect(body.path).toBe("/");
   });
 
   it("should handle paths with special characters", async () => {
@@ -440,7 +391,6 @@ describe("hono context integration", () => {
     const response = notFound(context, { message: "File not found" });
     const body = await response.json();
 
-    expect(body.path).toBe("/api/files/my%20file.txt");
     expect(body.message).toBe("File not found");
   });
 });

--- a/packages/worker-shared/test/errors.test.ts
+++ b/packages/worker-shared/test/errors.test.ts
@@ -44,14 +44,6 @@ describe("badRequest", () => {
     expect(body.status).toBe(400);
   });
 
-  it("should return 400 response with custom path", async () => {
-    const response = badRequest({ path: "/api/users" });
-    const body = await response.json();
-
-    expect(body.path).toBe("/api/users");
-    expect(body.status).toBe(400);
-  });
-
   it("should return 400 response with custom headers", async () => {
     const customHeaders = { "X-Custom-Header": "test-value" };
     const response = badRequest({ headers: customHeaders });
@@ -145,14 +137,6 @@ describe("forbidden", () => {
     expect(body.status).toBe(403);
   });
 
-  it("should return 403 response with custom path", async () => {
-    const response = forbidden({ path: "/api/admin" });
-    const body = await response.json();
-
-    expect(body.path).toBe("/api/admin");
-    expect(body.status).toBe(403);
-  });
-
   it("should return 403 response with custom headers", async () => {
     const customHeaders = { "WWW-Authenticate": "Bearer" };
     const response = forbidden({ headers: customHeaders });
@@ -205,14 +189,6 @@ describe("notFound", () => {
     const body = await response.json();
 
     expect(body.message).toBe("User not found");
-    expect(body.status).toBe(404);
-  });
-
-  it("should return 404 response with custom path", async () => {
-    const response = notFound({ path: "/api/users/999" });
-    const body = await response.json();
-
-    expect(body.path).toBe("/api/users/999");
     expect(body.status).toBe(404);
   });
 
@@ -276,14 +252,6 @@ describe("internalServerError", () => {
     const body = await response.json();
 
     expect(body.message).toBe("Database connection failed");
-    expect(body.status).toBe(500);
-  });
-
-  it("should return 500 response with custom path", async () => {
-    const response = internalServerError({ path: "/api/database" });
-    const body = await response.json();
-
-    expect(body.path).toBe("/api/database");
     expect(body.status).toBe(500);
   });
 


### PR DESCRIPTION
### 🔗 Linked issue

resolves #118

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR removes the path property on `ApiError`. This is needed to be able to implement something like #140

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to UCDJS!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error responses no longer include the request path in their payloads.
  * The API and proxy now log the request path internally when errors or not-found routes occur, but this information is not exposed in responses.

* **Tests**
  * Updated tests to remove assertions related to the presence of the `path` property in error responses.

* **Documentation**
  * Updated documentation and schema definitions to remove references to the `path` property in error objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->