### PR TITLE
feat(worker-shared): add createResponseComponentBuilder function

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -3,7 +3,7 @@ import { OpenAPIHono } from "@hono/zod-openapi";
 import { Scalar } from "@scalar/hono-api-reference";
 import { errorHandler, notFoundHandler, setupCors } from "@ucdjs/worker-shared";
 import { env } from "hono/adapter";
-import { buildOpenApiConfig } from "./openapi";
+import { buildOpenApiConfig, registerApp } from "./openapi";
 import { V1_FILES_ROUTER } from "./routes/v1_files";
 import { V1_UNICODE_PROXY_ROUTER } from "./routes/v1_unicode-proxy";
 import { V1_UNICODE_RELEASES_ROUTER } from "./routes/v1_unicode-releases";
@@ -11,6 +11,7 @@ import { V1_UNICODE_VERSIONS_ROUTER } from "./routes/v1_unicode-versions";
 
 const app = new OpenAPIHono<HonoEnv>();
 
+registerApp(app);
 setupCors(app);
 
 app.route("/", V1_UNICODE_VERSIONS_ROUTER);

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -1,5 +1,6 @@
 import type { OpenAPIHono } from "@hono/zod-openapi";
 import { dedent } from "@luxass/utils";
+import { createResponseComponentBuilder } from "@ucdjs/worker-shared";
 
 export type OpenAPIObjectConfig = Parameters<OpenAPIHono["getOpenAPI31Document"]>[0];
 
@@ -9,6 +10,14 @@ export const OPENAPI_TAGS = {
   FILES: "Files",
   RELEASES: "Releases",
 } as const satisfies Record<string, string>;
+
+export const { generateReferences, registerApp } = createResponseComponentBuilder([
+  400,
+  404,
+  429,
+  500,
+  502,
+]);
 
 export type OpenAPITag = typeof OPENAPI_TAGS[keyof typeof OPENAPI_TAGS];
 

--- a/apps/api/src/openapi.ts
+++ b/apps/api/src/openapi.ts
@@ -17,6 +17,7 @@ export const { generateReferences, registerApp } = createResponseComponentBuilde
   429,
   500,
   502,
+  503,
 ]);
 
 export type OpenAPITag = typeof OPENAPI_TAGS[keyof typeof OPENAPI_TAGS];

--- a/apps/api/src/routes/v1_files.openapi.ts
+++ b/apps/api/src/routes/v1_files.openapi.ts
@@ -1,5 +1,4 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { ApiErrorSchema } from "@ucdjs/worker-shared";
 import { generateReferences, OPENAPI_TAGS } from "../openapi";
 import { UnicodeVersionFileSchema } from "./v1_files.schemas";
 

--- a/apps/api/src/routes/v1_files.openapi.ts
+++ b/apps/api/src/routes/v1_files.openapi.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { ApiErrorSchema } from "@ucdjs/worker-shared";
-import { OPENAPI_TAGS } from "../openapi";
+import { generateReferences, OPENAPI_TAGS } from "../openapi";
 import { UnicodeVersionFileSchema } from "./v1_files.schemas";
 
 export const GET_UNICODE_FILES_BY_VERSION_ROUTE = createRoute({
@@ -28,37 +28,11 @@ export const GET_UNICODE_FILES_BY_VERSION_ROUTE = createRoute({
       },
       description: "A list of UCD files for the specified Unicode version.",
     },
-    400: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Bad Request",
-    },
-    429: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Rate Limit Exceeded",
-    },
-    500: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Internal Server Error",
-    },
-    502: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Bad Gateway",
-    },
+    ...(generateReferences([
+      400,
+      429,
+      500,
+      502,
+    ])),
   },
 });

--- a/apps/api/src/routes/v1_unicode-proxy.openapi.ts
+++ b/apps/api/src/routes/v1_unicode-proxy.openapi.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { ApiErrorSchema } from "@ucdjs/worker-shared";
-import { OPENAPI_TAGS } from "../openapi";
+import { generateReferences, OPENAPI_TAGS } from "../openapi";
 import { ProxyResponseSchema } from "./v1_unicode-proxy.schemas";
 
 const WILDCARD_PARAM = {
@@ -55,38 +55,12 @@ export const UNICODE_PROXY_WILDCARD_ROUTE = createRoute({
         },
       },
     },
-    400: {
-      description: "Bad request - invalid path",
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-    },
-    404: {
-      description: "Resource not found",
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-    },
-    500: {
-      description: "Internal server error",
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-    },
-    502: {
-      description: "Bad gateway - proxy request failed",
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-    },
+    ...(generateReferences([
+      400,
+      404,
+      500,
+      502,
+    ])),
   },
 });
 
@@ -115,37 +89,11 @@ export const UNICODE_PROXY_STAT_WILDCARD_ROUTE = createRoute({
         },
       },
     },
-    400: {
-      description: "Bad request - invalid path",
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-    },
-    404: {
-      description: "Resource not found",
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-    },
-    500: {
-      description: "Internal server error",
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-    },
-    502: {
-      description: "Bad gateway - proxy request failed",
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-    },
+    ...(generateReferences([
+      400,
+      404,
+      500,
+      502,
+    ])),
   },
 });

--- a/apps/api/src/routes/v1_unicode-proxy.openapi.ts
+++ b/apps/api/src/routes/v1_unicode-proxy.openapi.ts
@@ -1,5 +1,4 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { ApiErrorSchema } from "@ucdjs/worker-shared";
 import { generateReferences, OPENAPI_TAGS } from "../openapi";
 import { ProxyResponseSchema } from "./v1_unicode-proxy.schemas";
 

--- a/apps/api/src/routes/v1_unicode-releases.openapi.ts
+++ b/apps/api/src/routes/v1_unicode-releases.openapi.ts
@@ -1,5 +1,4 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { ApiErrorSchema } from "@ucdjs/worker-shared";
 import { generateReferences, OPENAPI_TAGS } from "../openapi";
 import { UnicodeVersionSchema } from "./v1_unicode-releases.schemas";
 

--- a/apps/api/src/routes/v1_unicode-releases.openapi.ts
+++ b/apps/api/src/routes/v1_unicode-releases.openapi.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { ApiErrorSchema } from "@ucdjs/worker-shared";
-import { OPENAPI_TAGS } from "../openapi";
+import { generateReferences, OPENAPI_TAGS } from "../openapi";
 import { UnicodeVersionSchema } from "./v1_unicode-releases.schemas";
 
 export const LIST_ALL_UNICODE_VERSIONS_ROUTE = createRoute({
@@ -17,29 +17,10 @@ export const LIST_ALL_UNICODE_VERSIONS_ROUTE = createRoute({
       },
       description: "A list of Unicode versions with metadata and support status.",
     },
-    404: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Not Found",
-    },
-    429: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Rate Limit Exceeded",
-    },
-    500: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Internal Server Error",
-    },
+    ...(generateReferences([
+      404,
+      429,
+      500,
+    ])),
   },
 });

--- a/apps/api/src/routes/v1_unicode-versions.openapi.ts
+++ b/apps/api/src/routes/v1_unicode-versions.openapi.ts
@@ -1,6 +1,6 @@
 import { createRoute, z } from "@hono/zod-openapi";
 import { ApiErrorSchema } from "@ucdjs/worker-shared";
-import { OPENAPI_TAGS } from "../openapi";
+import { generateReferences, OPENAPI_TAGS } from "../openapi";
 import { UnicodeVersionMappingsSchema, UnicodeVersionSchema } from "./v1_unicode-versions.schemas";
 
 export const LIST_ALL_UNICODE_VERSIONS_ROUTE = createRoute({
@@ -18,14 +18,6 @@ export const LIST_ALL_UNICODE_VERSIONS_ROUTE = createRoute({
       },
       description: "A list of Unicode versions with metadata.",
     },
-    404: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Not Found",
-    },
     429: {
       content: {
         "application/json": {
@@ -34,14 +26,10 @@ export const LIST_ALL_UNICODE_VERSIONS_ROUTE = createRoute({
       },
       description: "Rate Limit Exceeded",
     },
-    500: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Internal Server Error",
-    },
+    ...(generateReferences([
+      404,
+      500,
+    ])),
   },
 });
 
@@ -60,13 +48,8 @@ export const GET_UNICODE_MAPPINGS = createRoute({
       },
       description: "A list of Unicode versions mappings",
     },
-    500: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Internal Server Error",
-    },
+    ...(generateReferences([
+      500,
+    ])),
   },
 });

--- a/apps/api/src/routes/v1_unicode-versions.openapi.ts
+++ b/apps/api/src/routes/v1_unicode-versions.openapi.ts
@@ -1,5 +1,4 @@
 import { createRoute, z } from "@hono/zod-openapi";
-import { ApiErrorSchema } from "@ucdjs/worker-shared";
 import { generateReferences, OPENAPI_TAGS } from "../openapi";
 import { UnicodeVersionMappingsSchema, UnicodeVersionSchema } from "./v1_unicode-versions.schemas";
 
@@ -18,16 +17,9 @@ export const LIST_ALL_UNICODE_VERSIONS_ROUTE = createRoute({
       },
       description: "A list of Unicode versions with metadata.",
     },
-    429: {
-      content: {
-        "application/json": {
-          schema: ApiErrorSchema,
-        },
-      },
-      description: "Rate Limit Exceeded",
-    },
     ...(generateReferences([
       404,
+      429,
       500,
     ])),
   },

--- a/packages/fetch/src/components.ts
+++ b/packages/fetch/src/components.ts
@@ -6,9 +6,9 @@
 
 import type { components } from "./.generated/api";
 
+export type ApiError = components["schemas"]["ApiError"];
 export type UnicodeVersion = components["schemas"]["UnicodeVersion"];
 export type UnicodeVersions = components["schemas"]["UnicodeVersions"];
-export type ApiError = components["schemas"]["ApiError"];
 export type UnicodeVersionMappings = components["schemas"]["UnicodeVersionMappings"];
 export type ProxyDirectoryResponse = components["schemas"]["ProxyDirectoryResponse"];
 export type ProxyFileResponse = components["schemas"]["ProxyFileResponse"];

--- a/packages/worker-shared/src/index.ts
+++ b/packages/worker-shared/src/index.ts
@@ -9,8 +9,9 @@ export {
 export type { CustomResponseOptions, ResponseOptions } from "./errors";
 
 export { errorHandler, notFoundHandler } from "./handlers";
+export { createResponseComponentBuilder } from "./openapi";
+
 export type { ApiError } from "./schemas";
 
 export { ApiErrorSchema } from "./schemas";
-
 export { setupCors } from "./setups";

--- a/packages/worker-shared/src/openapi.ts
+++ b/packages/worker-shared/src/openapi.ts
@@ -44,6 +44,14 @@ export function createResponseComponentBuilder<TCodes extends HonoErrorStatusCod
 ): ResponseComponentBuilder<TCodes> {
   return {
     registerApp(app: OpenAPIHono<any>) {
+      if (!app.openAPIRegistry) {
+        throw new Error("OpenAPI registry is not initialized in the app");
+      }
+
+      if (!app.openAPIRegistry.definitions.find((d) => d.type === "component" && d.name === "ApiError")) {
+        app.openAPIRegistry.register("ApiError", ApiErrorSchema);
+      }
+
       for (const statusCode of codes) {
         const componentName = RESPONSE_COMPONENT_NAMES[statusCode];
         const description = ERROR_DESCRIPTIONS[statusCode];

--- a/packages/worker-shared/src/openapi.ts
+++ b/packages/worker-shared/src/openapi.ts
@@ -1,4 +1,5 @@
 import type { OpenAPIHono } from "@hono/zod-openapi";
+import type { Env } from "hono";
 import type { ClientErrorStatusCode, ServerErrorStatusCode } from "hono/utils/http-status";
 import { ApiErrorSchema } from "./schemas";
 
@@ -54,7 +55,7 @@ export interface ResponseComponentBuilder<TCodes extends readonly SupportedStatu
   /**
    * Registers error response components with the OpenAPI registry
    */
-  registerApp: (app: OpenAPIHono<any>) => void;
+  registerApp: <TEnv extends Env>(app: OpenAPIHono<TEnv>) => void;
 
   /**
    * Generates response references for the specified status codes
@@ -104,7 +105,7 @@ export function createResponseComponentBuilder<TCodes extends readonly Supported
   }
 
   return {
-    registerApp(app: OpenAPIHono<any>) {
+    registerApp<TEnv extends Env>(app: OpenAPIHono<TEnv>) {
       if (!app.openAPIRegistry) {
         throw new Error("OpenAPI registry is not initialized in the app");
       }

--- a/packages/worker-shared/src/openapi.ts
+++ b/packages/worker-shared/src/openapi.ts
@@ -81,7 +81,6 @@ export function createResponseComponentBuilder<TCodes extends HonoErrorStatusCod
           content: {
             "application/json": {
               schema: {
-                type: "object",
                 $ref: "#/components/schemas/ApiError",
               },
             },

--- a/packages/worker-shared/src/openapi.ts
+++ b/packages/worker-shared/src/openapi.ts
@@ -1,0 +1,89 @@
+import type { OpenAPIHono, RouteConfig } from "@hono/zod-openapi";
+import type { ClientErrorStatusCode, ServerErrorStatusCode } from "hono/utils/http-status";
+import { ApiErrorSchema } from "./schemas";
+
+type HonoErrorStatusCode = ClientErrorStatusCode | ServerErrorStatusCode;
+type AstreaResponseObject = RouteConfig["responses"];
+type AstreaResponseType = AstreaResponseObject[keyof AstreaResponseObject];
+
+const ERROR_DESCRIPTIONS: Partial<Record<HonoErrorStatusCode, string>> = {
+  400: "Bad request error",
+  401: "Unauthorized error",
+  403: "Forbidden error",
+  404: "Resource not found",
+  409: "Resource conflict",
+  422: "Validation error",
+  429: "Rate limit exceeded",
+  500: "Internal server error",
+  502: "Bad gateway - upstream service failed",
+  503: "Service temporarily unavailable",
+  504: "Gateway timeout",
+};
+
+const RESPONSE_COMPONENT_NAMES: Partial<Record<HonoErrorStatusCode, string>> = {
+  400: "BadRequestError",
+  401: "UnauthorizedError",
+  403: "ForbiddenError",
+  404: "NotFoundError",
+  409: "ConflictError",
+  422: "ValidationError",
+  429: "TooManyRequestsError",
+  500: "InternalServerError",
+  502: "BadGatewayError",
+  503: "ServiceUnavailableError",
+  504: "GatewayTimeoutError",
+};
+
+export interface ResponseComponentBuilder<TCodes extends HonoErrorStatusCode[]> {
+  registerApp: (app: OpenAPIHono<any>) => void;
+  generateReferences: (codes: TCodes) => Record<string, AstreaResponseType>;
+}
+
+export function createResponseComponentBuilder<TCodes extends HonoErrorStatusCode[]>(
+  codes: TCodes,
+): ResponseComponentBuilder<TCodes> {
+  return {
+    registerApp(app: OpenAPIHono<any>) {
+      for (const statusCode of codes) {
+        const componentName = RESPONSE_COMPONENT_NAMES[statusCode];
+        const description = ERROR_DESCRIPTIONS[statusCode];
+
+        if (!componentName) {
+          throw new Error(`No component name defined for status code ${statusCode}`);
+        }
+
+        if (!description) {
+          throw new Error(`No description defined for status code ${statusCode}`);
+        }
+
+        const responseConfig = {
+          description,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                $ref: "#/components/schemas/ApiError",
+              },
+            },
+          },
+        };
+
+        app.openAPIRegistry.registerComponent("responses", componentName, responseConfig);
+      }
+    },
+
+    generateReferences(codes: TCodes) {
+      const references: Record<string, AstreaResponseType> = {};
+      for (const statusCode of codes) {
+        const componentName = RESPONSE_COMPONENT_NAMES[statusCode];
+        if (componentName) {
+          references[statusCode] = {
+            $ref: `#/components/responses/${componentName}`,
+          };
+        }
+      }
+
+      return references;
+    },
+  };
+}

--- a/packages/worker-shared/test/openapi.test.ts
+++ b/packages/worker-shared/test/openapi.test.ts
@@ -1,0 +1,296 @@
+import type { OpenAPIHono } from "@hono/zod-openapi";
+import type { Env } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createResponseComponentBuilder } from "../src/openapi";
+import { ApiErrorSchema } from "../src/schemas";
+
+const VALID_CLIENT_ERROR_CODES = [400, 401, 403, 404, 409, 422, 429] as const;
+const VALID_SERVER_ERROR_CODES = [500, 502, 503, 504] as const;
+const ALL_VALID_CODES = [
+  ...VALID_CLIENT_ERROR_CODES,
+  ...VALID_SERVER_ERROR_CODES,
+] as const;
+const INVALID_CODES = [200, 300, 999, 123] as const;
+
+function createMockApp() {
+  return {
+    openAPIRegistry: {
+      definitions: [] as Array<{ type: string; name: string }>,
+      register: vi.fn(),
+      registerComponent: vi.fn(),
+    },
+  } as unknown as OpenAPIHono<Env>;
+}
+
+function expectComponentRegistration(
+  mockApp: ReturnType<typeof createMockApp>,
+  componentName: string,
+  description: string,
+) {
+  expect(mockApp.openAPIRegistry.registerComponent).toHaveBeenCalledWith(
+    "responses",
+    componentName,
+    {
+      description,
+      content: {
+        "application/json": {
+          schema: {
+            $ref: "#/components/schemas/ApiError",
+          },
+        },
+      },
+    },
+  );
+}
+
+describe("createResponseComponentBuilder", () => {
+  let mockApp: ReturnType<typeof createMockApp>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockApp = createMockApp();
+  });
+
+  describe("initialization and validation", () => {
+    it("should create builder successfully with valid status codes", () => {
+      expect(() => createResponseComponentBuilder([400, 404, 500])).not.toThrow();
+    });
+
+    it("should throw descriptive error for unsupported status codes", () => {
+      const [invalidCode] = INVALID_CODES;
+      expect(() => createResponseComponentBuilder([invalidCode] as any)).toThrow(
+        `Unsupported status code: ${invalidCode}`,
+      );
+    });
+
+    it("should validate all codes and throw for first invalid one", () => {
+      const [firstInvalid, secondInvalid] = INVALID_CODES;
+      expect(() => createResponseComponentBuilder([400, firstInvalid, secondInvalid] as any)).toThrow(
+        `Unsupported status code: ${firstInvalid}`,
+      );
+    });
+
+    it("should reject all invalid status codes", () => {
+      INVALID_CODES.forEach((invalidCode) => {
+        expect(() => createResponseComponentBuilder([invalidCode] as any)).toThrow(
+          `Unsupported status code: ${invalidCode}`,
+        );
+      });
+    });
+
+    it("should accept all supported error codes", () => {
+      expect(() => createResponseComponentBuilder(ALL_VALID_CODES)).not.toThrow();
+    });
+
+    it("should work with empty array", () => {
+      expect(() => createResponseComponentBuilder([])).not.toThrow();
+    });
+  });
+
+  describe("registerApp method", () => {
+    it("should throw when OpenAPI registry is missing", () => {
+      const builder = createResponseComponentBuilder([400]);
+      const appWithoutRegistry = {} as OpenAPIHono<Env>;
+
+      expect(() => builder.registerApp(appWithoutRegistry)).toThrow(
+        "OpenAPI registry is not initialized in the app",
+      );
+    });
+
+    it("should register ApiError schema when not present", () => {
+      const builder = createResponseComponentBuilder([400]);
+
+      builder.registerApp(mockApp);
+
+      expect(mockApp.openAPIRegistry.register).toHaveBeenCalledWith("ApiError", ApiErrorSchema);
+    });
+
+    it("should skip ApiError schema registration when already present", () => {
+      mockApp.openAPIRegistry.definitions.push({
+        type: "component",
+        name: "ApiError",
+        component: {
+          schema: {},
+        },
+        componentType: "schemas",
+      });
+      const builder = createResponseComponentBuilder([400]);
+
+      builder.registerApp(mockApp);
+
+      expect(mockApp.openAPIRegistry.register).not.toHaveBeenCalled();
+    });
+
+    it("should register response components for all provided codes", () => {
+      const codes = [400, 404, 500] as const;
+      const builder = createResponseComponentBuilder(codes);
+
+      builder.registerApp(mockApp);
+
+      expect(mockApp.openAPIRegistry.registerComponent).toHaveBeenCalledTimes(3);
+      expectComponentRegistration(mockApp, "BadRequestError", "Bad request error");
+      expectComponentRegistration(mockApp, "NotFoundError", "Resource not found");
+      expectComponentRegistration(mockApp, "InternalServerError", "Internal server error");
+    });
+
+    it("should handle single status code registration", () => {
+      const builder = createResponseComponentBuilder([422]);
+
+      builder.registerApp(mockApp);
+
+      expectComponentRegistration(mockApp, "ValidationError", "Validation error");
+    });
+
+    it("should handle empty codes array", () => {
+      const builder = createResponseComponentBuilder([]);
+
+      builder.registerApp(mockApp);
+
+      expect(mockApp.openAPIRegistry.register).toHaveBeenCalledWith("ApiError", ApiErrorSchema);
+      expect(mockApp.openAPIRegistry.registerComponent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("generateReferences method", () => {
+    it("should generate correct references for given codes", () => {
+      const builder = createResponseComponentBuilder([400, 404, 500]);
+
+      const references = builder.generateReferences([400, 404]);
+
+      expect(references).toEqual({
+        400: { $ref: "#/components/responses/BadRequestError" },
+        404: { $ref: "#/components/responses/NotFoundError" },
+      });
+    });
+
+    it("should generate reference for single code", () => {
+      const builder = createResponseComponentBuilder([401]);
+
+      const references = builder.generateReferences([401]);
+
+      expect(references).toEqual({
+        401: { $ref: "#/components/responses/UnauthorizedError" },
+      });
+    });
+
+    it("should return empty object for empty codes array", () => {
+      const builder = createResponseComponentBuilder([400]);
+
+      const references = builder.generateReferences([]);
+
+      expect(references).toEqual({});
+    });
+
+    it("should generate references for all error types", () => {
+      const testCases = [
+        { code: 400, component: "BadRequestError" },
+        { code: 401, component: "UnauthorizedError" },
+        { code: 403, component: "ForbiddenError" },
+        { code: 404, component: "NotFoundError" },
+        { code: 409, component: "ConflictError" },
+        { code: 422, component: "ValidationError" },
+        { code: 429, component: "TooManyRequestsError" },
+        { code: 500, component: "InternalServerError" },
+        { code: 502, component: "BadGatewayError" },
+        { code: 503, component: "ServiceUnavailableError" },
+        { code: 504, component: "GatewayTimeoutError" },
+      ] as const;
+
+      testCases.forEach(({ code, component }) => {
+        const builder = createResponseComponentBuilder([code]);
+        const references = builder.generateReferences([code]);
+
+        expect(references[code]).toEqual({
+          $ref: `#/components/responses/${component}`,
+        });
+      });
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should handle typical REST API setup", () => {
+      const restCodes = [400, 401, 403, 404, 422, 500] as const;
+      const builder = createResponseComponentBuilder(restCodes);
+
+      builder.registerApp(mockApp);
+      const references = builder.generateReferences([400, 404, 500]);
+
+      expect(mockApp.openAPIRegistry.registerComponent).toHaveBeenCalledTimes(6);
+      expect(references).toEqual({
+        400: { $ref: "#/components/responses/BadRequestError" },
+        404: { $ref: "#/components/responses/NotFoundError" },
+        500: { $ref: "#/components/responses/InternalServerError" },
+      });
+    });
+
+    it("should handle microservice gateway scenarios", () => {
+      const gatewayCodes = [502, 503, 504] as const;
+      const builder = createResponseComponentBuilder(gatewayCodes);
+
+      builder.registerApp(mockApp);
+      const references = builder.generateReferences(gatewayCodes);
+
+      expect(references).toEqual({
+        502: { $ref: "#/components/responses/BadGatewayError" },
+        503: { $ref: "#/components/responses/ServiceUnavailableError" },
+        504: { $ref: "#/components/responses/GatewayTimeoutError" },
+      });
+    });
+
+    it("should work with rate-limited APIs", () => {
+      const builder = createResponseComponentBuilder([429]);
+
+      builder.registerApp(mockApp);
+      const references = builder.generateReferences([429]);
+
+      expectComponentRegistration(mockApp, "TooManyRequestsError", "Rate limit exceeded");
+      expect(references[429]).toEqual({
+        $ref: "#/components/responses/TooManyRequestsError",
+      });
+    });
+
+    it("should support full workflow with all codes", () => {
+      const builder = createResponseComponentBuilder(ALL_VALID_CODES);
+
+      // should register without errors
+      expect(() => builder.registerApp(mockApp)).not.toThrow();
+
+      // should register all components
+      expect(mockApp.openAPIRegistry.registerComponent).toHaveBeenCalledTimes(ALL_VALID_CODES.length);
+
+      // should generate all references
+      const allReferences = builder.generateReferences(ALL_VALID_CODES);
+      expect(Object.keys(allReferences)).toHaveLength(ALL_VALID_CODES.length);
+
+      expect(
+        // @ts-expect-error - $ref is the only property there, the entire type is a lie.
+        allReferences[400].$ref,
+      ).toBe("#/components/responses/BadRequestError");
+      expect(
+        // @ts-expect-error - $ref is the only property there, the entire type is a lie.
+        allReferences[500].$ref,
+      ).toBe("#/components/responses/InternalServerError");
+    });
+  });
+
+  describe("type safety and constraints", () => {
+    it("should maintain type safety for status codes", () => {
+      const builder = createResponseComponentBuilder([400, 404] as const);
+
+      const subset = builder.generateReferences([400] as const);
+      const all = builder.generateReferences([400, 404] as const);
+
+      expect(subset[400]).toBeDefined();
+      expect(all[400]).toBeDefined();
+      expect(all[404]).toBeDefined();
+    });
+
+    it("should work with readonly arrays", () => {
+      const codes = [400, 500] as const;
+      const builder = createResponseComponentBuilder(codes);
+
+      expect(() => builder.registerApp(mockApp)).not.toThrow();
+      expect(() => builder.generateReferences(codes)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

#140 

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to UCDJS!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for standardized error responses including HTTP 503 status in API documentation.
  * Introduced centralized registration and reuse of error response components across API routes for improved consistency.

* **Refactor**
  * Further unified and simplified error response definitions in API routes by leveraging a shared utility function.
  * Enhanced OpenAPI response component management to streamline error handling documentation.

* **Tests**
  * Added comprehensive tests for the new response component builder to ensure correctness and type safety.

* **Chores**
  * Exported new utilities for response component creation to improve developer experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->