### PR TITLE
chore(eslint): add no-restricted-imports rule to ESLint configuration

### DIFF
--- a/apps/api/eslint.config.js
+++ b/apps/api/eslint.config.js
@@ -4,18 +4,20 @@ import ucdjsPlugin from "@ucdjs/eslint-plugin";
 
 export default luxass({
   formatters: true,
-}, {
-  ignores: [
-    "worker-configuration.d.ts",
-  ],
-}).append({
-  plugins: {
-    ucdjs: ucdjsPlugin,
-  },
-  files: [
-    "**/*.openapi.ts",
-  ],
-  rules: {
-    "ucdjs/no-hardcoded-openapi-tags": "error",
-  },
-});
+})
+  .append({
+    ignores: [
+      "worker-configuration.d.ts",
+    ],
+  })
+  .append({
+    plugins: {
+      ucdjs: ucdjsPlugin,
+    },
+    files: [
+      "**/*.openapi.ts",
+    ],
+    rules: {
+      "ucdjs/no-hardcoded-openapi-tags": "error",
+    },
+  });

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -5,7 +5,7 @@ export default luxass({
   react: true,
   tailwindcss: false,
   pnpm: true,
-}, {
+}).append({
   ignores: [
     "src/routeTree.gen.ts",
   ],

--- a/packages/cli/eslint.config.js
+++ b/packages/cli/eslint.config.js
@@ -4,6 +4,4 @@ import { luxass } from "@luxass/eslint-config";
 export default luxass({
   type: "app",
   pnpm: true,
-}, {
-  ignores: ["**/*.md"],
 });

--- a/packages/env/eslint.config.js
+++ b/packages/env/eslint.config.js
@@ -4,6 +4,4 @@ import { luxass } from "@luxass/eslint-config";
 export default luxass({
   type: "lib",
   pnpm: true,
-}, {
-  ignores: ["**/*.md"],
 });

--- a/packages/fetch/README.md
+++ b/packages/fetch/README.md
@@ -17,56 +17,57 @@ npm install @ucdjs/fetch
 ### Basic Usage
 
 ```typescript
-import { client } from '@ucdjs/fetch';
+import { client } from "@ucdjs/fetch";
 
 // Get Unicode versions
-const { data: versions, error } = await client.GET('/api/v1/unicode-versions');
+const { data: versions, error } = await client.GET("/api/v1/unicode-versions");
 if (error) {
-  console.error('Error:', error.message);
+  console.error("Error:", error.message);
 } else {
-  console.log('Available versions:', versions);
+  console.log("Available versions:", versions);
 }
 
 // Access Unicode data files via proxy
-const { data: fileInfo } = await client.GET('/api/v1/unicode-proxy/{wildcard}', {
+const { data: fileInfo } = await client.GET("/api/v1/unicode-proxy/{wildcard}", {
   params: {
-    path: { wildcard: 'latest/ucd.all.json' }
+    path: { wildcard: "latest/ucd.all.json" }
   }
 });
-console.log('File info:', fileInfo);
+console.log("File info:", fileInfo);
 ```
 
 ### Custom Client Configuration
 
 ```typescript
-import { createClient } from '@ucdjs/fetch';
+import { createClient } from "@ucdjs/fetch";
 
 // Create client with custom UCD.js API instance
-const customClient = createClient('https://preview.api.ucdjs.dev');
+const customClient = createClient("https://preview.api.ucdjs.dev");
 
 // Use the custom client
-const { data, error } = await customClient.GET('/api/v1/unicode-versions');
+const { data, error } = await customClient.GET("/api/v1/unicode-versions");
 if (data) {
-  console.log('Unicode versions from preview API:', data);
+  console.log("Unicode versions from preview API:", data);
 }
 ```
 
 ### Working with Binary Data
 
 ```typescript
-import { client } from '@ucdjs/fetch';
+import { client } from "@ucdjs/fetch";
 
 // Fetch binary Unicode data file
-const { data: binaryData } = await client.GET('/api/v1/unicode-proxy/{wildcard}', {
+const { data: binaryData } = await client.GET("/api/v1/unicode-proxy/{wildcard}", {
   params: {
-    path: { wildcard: 'latest/UnicodeData.txt' }
+    path: { wildcard: "latest/UnicodeData.txt" }
   },
-  parseAs: 'arrayBuffer'
+  parseAs: "arrayBuffer"
 });
 
 if (binaryData) {
-  const text = Buffer.from(binaryData).toString('utf-8');
-  console.log('Unicode data:', text.substring(0, 100) + '...');
+  // eslint-disable-next-line node/prefer-global/buffer
+  const text = Buffer.from(binaryData).toString("utf-8");
+  console.log("Unicode data:", `${text.substring(0, 100)}...`);
 }
 ```
 

--- a/packages/fetch/eslint.config.js
+++ b/packages/fetch/eslint.config.js
@@ -4,6 +4,4 @@ import { luxass } from "@luxass/eslint-config";
 export default luxass({
   type: "lib",
   pnpm: true,
-}, {
-  ignores: ["**/*.md"],
 });

--- a/packages/fs-bridge/README.md
+++ b/packages/fs-bridge/README.md
@@ -21,7 +21,7 @@ You can create your own filesystem bridge or use the preconfigured ones provided
 You can define a custom filesystem bridge using the `defineFileSystemBridge` function. This allows you to implement your own file system operations.
 
 ```typescript
-import { defineFileSystemBridge } from '@ucdjs/fs-bridge';
+import { defineFileSystemBridge } from "@ucdjs/fs-bridge";
 
 const MyFileSystemBridge = defineFileSystemBridge({
   read: async (path) => {
@@ -53,34 +53,34 @@ const MyFileSystemBridge = defineFileSystemBridge({
 #### Node.js File System Bridge
 
 ```typescript
-import NodeFileSystemBridge from '@ucdjs/fs-bridge/bridges/node';
+import NodeFileSystemBridge from "@ucdjs/fs-bridge/bridges/node";
 
 // Read a file
-const content = await NodeFileSystemBridge.read('/path/to/file.txt');
+const content = await NodeFileSystemBridge.read("/path/to/file.txt");
 
 // Write a file
-await NodeFileSystemBridge.write('/path/to/file.txt', 'Hello World');
+await NodeFileSystemBridge.write("/path/to/file.txt", "Hello World");
 
 // List directory contents
-const files = await NodeFileSystemBridge.listdir('/path/to/dir');
-const allFiles = await NodeFileSystemBridge.listdir('/path/to/dir', true); // recursive
+const files = await NodeFileSystemBridge.listdir("/path/to/dir");
+const allFiles = await NodeFileSystemBridge.listdir("/path/to/dir", true); // recursive
 
 // Create directory
-await NodeFileSystemBridge.mkdir('/path/to/new/dir');
+await NodeFileSystemBridge.mkdir("/path/to/new/dir");
 
 // Check if file exists
-const exists = await NodeFileSystemBridge.exists('/path/to/file.txt');
+const exists = await NodeFileSystemBridge.exists("/path/to/file.txt");
 
 // Get file stats
-const stats = await NodeFileSystemBridge.stat('/path/to/file.txt');
+const stats = await NodeFileSystemBridge.stat("/path/to/file.txt");
 console.log(stats.isFile()); // true/false
 console.log(stats.isDirectory()); // true/false
 console.log(stats.size); // file size in bytes
 console.log(stats.mtime); // last modified date
 
 // Remove file/directory
-await NodeFileSystemBridge.rm('/path/to/file.txt');
-await NodeFileSystemBridge.rm('/path/to/dir', { recursive: true, force: true });
+await NodeFileSystemBridge.rm("/path/to/file.txt");
+await NodeFileSystemBridge.rm("/path/to/dir", { recursive: true, force: true });
 ```
 
 #### HTTP File System Bridge
@@ -88,25 +88,24 @@ await NodeFileSystemBridge.rm('/path/to/dir', { recursive: true, force: true });
 Read-only filesystem bridge for accessing files over HTTP/HTTPS:
 
 ```typescript
-import HTTPFileSystemBridge from '@ucdjs/fs-bridge/bridges/http';
+import HTTPFileSystemBridge from "@ucdjs/fs-bridge/bridges/http";
 
 const httpFS = HTTPFileSystemBridge({
-  baseUrl: 'https://example.com/files/'
+  baseUrl: "https://example.com/files/"
 });
 
 // Read remote file
-const content = await httpFS.read('/data/file.txt');
+const content = await httpFS.read("/data/file.txt");
 
 // List remote directory
-const files = await httpFS.listdir('/data/');
+const files = await httpFS.listdir("/data/");
 
 // Check if remote file exists
-const exists = await httpFS.exists('/data/file.txt');
+const exists = await httpFS.exists("/data/file.txt");
 
 // Get remote file stats
-const stats = await httpFS.stat('/data/file.txt');
+const stats = await httpFS.stat("/data/file.txt");
 ```
-
 
 ## 📄 License
 

--- a/packages/fs-bridge/eslint.config.js
+++ b/packages/fs-bridge/eslint.config.js
@@ -4,6 +4,13 @@ import { luxass } from "@luxass/eslint-config";
 export default luxass({
   type: "lib",
   pnpm: true,
-}, {
-  ignores: ["**/*.md"],
+}).append({
+  ignores: ["src/bridges/node.ts"],
+  rules: {
+    "no-restricted-imports": ["error", {
+      patterns: [
+        "node:*",
+      ],
+    }],
+  },
 });

--- a/packages/schema-gen/eslint.config.js
+++ b/packages/schema-gen/eslint.config.js
@@ -4,6 +4,4 @@ import { luxass } from "@luxass/eslint-config";
 export default luxass({
   type: "lib",
   pnpm: true,
-}, {
-  ignores: ["**/*.md"],
 });

--- a/packages/ucd-store/eslint.config.js
+++ b/packages/ucd-store/eslint.config.js
@@ -4,9 +4,8 @@ import { luxass } from "@luxass/eslint-config";
 export default luxass({
   type: "lib",
   pnpm: true,
-}, {
-  ignores: ["**/*.md"],
-}, {
+}).append({
+  ignores: ["./playgrounds/node-playground.ts"],
   rules: {
     "no-restricted-imports": ["error", {
       patterns: [

--- a/packages/ucd-store/eslint.config.js
+++ b/packages/ucd-store/eslint.config.js
@@ -6,4 +6,12 @@ export default luxass({
   pnpm: true,
 }, {
   ignores: ["**/*.md"],
+}, {
+  rules: {
+    "no-restricted-imports": ["error", {
+      patterns: [
+        "node:*",
+      ],
+    }],
+  },
 });

--- a/packages/ucd-store/eslint.config.js
+++ b/packages/ucd-store/eslint.config.js
@@ -5,7 +5,7 @@ export default luxass({
   type: "lib",
   pnpm: true,
 }).append({
-  ignores: ["./playgrounds/node-playground.ts"],
+  ignores: ["playgrounds/node-playground.ts"],
   rules: {
     "no-restricted-imports": ["error", {
       patterns: [

--- a/packages/utils/README.md
+++ b/packages/utils/README.md
@@ -19,11 +19,11 @@ npm install @ucdjs/utils
 Creates a filter function that checks if a file path should be included or excluded based on glob patterns.
 
 ```typescript
-import { createPathFilter } from '@ucdjs/utils';
+import { createPathFilter } from "@ucdjs/utils";
 
-const filter = createPathFilter(['*.txt', '!*Test*']);
-filter('Data.txt'); // true
-filter('DataTest.txt'); // false
+const filter = createPathFilter(["*.txt", "!*Test*"]);
+filter("Data.txt"); // true
+filter("DataTest.txt"); // false
 ```
 
 #### PathFilter Methods
@@ -31,16 +31,16 @@ filter('DataTest.txt'); // false
 The `PathFilter` object provides additional methods:
 
 ```typescript
-const filter = createPathFilter(['*.js']);
+const filter = createPathFilter(["*.js"]);
 
 // Extend with additional patterns
-filter.extend(['*.ts', '!*.test.*']);
+filter.extend(["*.ts", "!*.test.*"]);
 
 // Get current patterns
 const patterns = filter.patterns(); // ['*.js', '*.ts', '!*.test.*']
 
 // Use with extra filters temporarily
-filter('app.js', ['!src/**']); // Apply extra exclusions
+filter("app.js", ["!src/**"]); // Apply extra exclusions
 ```
 
 ### Preconfigured Filters
@@ -48,10 +48,10 @@ filter('app.js', ['!src/**']); // Apply extra exclusions
 Pre-defined filter patterns for common exclusions:
 
 ```typescript
-import { createPathFilter, PRECONFIGURED_FILTERS } from '@ucdjs/utils';
+import { createPathFilter, PRECONFIGURED_FILTERS } from "@ucdjs/utils";
 
 const filter = createPathFilter([
-  '*.txt',
+  "*.txt",
   PRECONFIGURED_FILTERS.EXCLUDE_TEST_FILES,
   PRECONFIGURED_FILTERS.EXCLUDE_README_FILES,
   PRECONFIGURED_FILTERS.EXCLUDE_HTML_FILES

--- a/packages/utils/eslint.config.js
+++ b/packages/utils/eslint.config.js
@@ -4,6 +4,4 @@ import { luxass } from "@luxass/eslint-config";
 export default luxass({
   type: "lib",
   pnpm: true,
-}, {
-  ignores: ["**/*.md"],
 });

--- a/packages/worker-shared/README.md
+++ b/packages/worker-shared/README.md
@@ -2,7 +2,6 @@
 
 [![codecov][codecov-src]][codecov-href]
 
-
 This is an internal package used by the UCDJS workers. It provides shared utilities and types for the workers to interact with each other.
 
 ## 📄 License

--- a/packages/worker-shared/eslint.config.js
+++ b/packages/worker-shared/eslint.config.js
@@ -4,6 +4,4 @@ import { luxass } from "@luxass/eslint-config";
 export default luxass({
   type: "lib",
   pnpm: true,
-}, {
-  ignores: ["**/*.md"],
 });


### PR DESCRIPTION
### 🔗 Linked issue

resolves #184 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to UCDJS!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined ESLint configuration across multiple packages for improved consistency and maintainability.
  * Updated ignore patterns in some packages to target specific files instead of broader file types.
  * Introduced stricter import rules in select packages to prevent usage of certain import patterns.

* **Chores**
  * Removed explicit ignore rules for markdown files in several packages' ESLint configurations.
  * Minor formatting cleanup in the worker-shared package README.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->