### PR TITLE
refactor(ucd-store): drop support for `toStoreError`

### DIFF
--- a/.changeset/five-tables-sip.md
+++ b/.changeset/five-tables-sip.md
@@ -1,0 +1,5 @@
+---
+"@ucdjs/ucd-store": patch
+---
+
+drop `toStoreError` function on Store Runtime Errors

--- a/packages/ucd-store/src/errors.ts
+++ b/packages/ucd-store/src/errors.ts
@@ -1,24 +1,22 @@
-/* eslint-disable ts/explicit-function-return-type */
-
+// Base error class for UCD Store
+// All store errors extend this class, to make it easier
+// to filter errors.
 export abstract class UCDStoreBaseError extends Error {
-  abstract "~toStoreError"(): any;
+  constructor(message: string) {
+    super(message);
+    this.name = "UCDStoreBaseError";
+  }
+
+  // prevents throwing this
 }
 
-export class UCDStoreError extends UCDStoreBaseError {
-  private data?: Record<string, unknown>;
+export class UCDStoreGenericError extends UCDStoreBaseError {
+  public readonly data?: Record<string, unknown>;
 
   constructor(message: string, data?: Record<string, unknown>) {
     super(message);
-    this.name = "UCDStoreError";
+    this.name = "UCDStoreGenericError";
     this.data = data;
-  }
-
-  "~toStoreError"() {
-    return {
-      type: "GENERIC" as const,
-      message: this.message,
-      ...(this.data && { data: this.data }),
-    };
   }
 }
 
@@ -32,15 +30,6 @@ export class UCDStoreFileNotFoundError extends UCDStoreBaseError {
     this.filePath = filePath;
     this.version = version;
   }
-
-  "~toStoreError"() {
-    return {
-      type: "FILE_NOT_FOUND" as const,
-      message: this.message,
-      filePath: this.filePath,
-      ...(this.version && { version: this.version }),
-    };
-  }
 }
 
 export class UCDStoreVersionNotFoundError extends UCDStoreBaseError {
@@ -50,14 +39,6 @@ export class UCDStoreVersionNotFoundError extends UCDStoreBaseError {
     super(`Version '${version}' does not exist in the store.`);
     this.name = "UCDStoreVersionNotFoundError";
     this.version = version;
-  }
-
-  "~toStoreError"() {
-    return {
-      type: "UNSUPPORTED_VERSION" as const,
-      version: this.version,
-      message: this.message,
-    };
   }
 }
 
@@ -79,16 +60,6 @@ export class UCDStoreBridgeUnsupportedOperation extends UCDStoreBaseError {
     this.requiredCapabilities = requiredCapabilities;
     this.availableCapabilities = availableCapabilities;
   }
-
-  "~toStoreError"() {
-    return {
-      type: "BRIDGE_UNSUPPORTED_OPERATION" as const,
-      operation: this.operation,
-      message: this.message,
-      requiredCapabilities: this.requiredCapabilities,
-      availableCapabilities: this.availableCapabilities,
-    };
-  }
 }
 
 export class UCDStoreInvalidManifestError extends UCDStoreBaseError {
@@ -99,14 +70,6 @@ export class UCDStoreInvalidManifestError extends UCDStoreBaseError {
     this.name = "UCDStoreInvalidManifestError";
     this.manifestPath = manifestPath;
   }
-
-  "~toStoreError"() {
-    return {
-      type: "INVALID_MANIFEST" as const,
-      manifestPath: this.manifestPath,
-      message: this.message,
-    };
-  }
 }
 
 export class UCDStoreNotInitializedError extends UCDStoreBaseError {
@@ -114,26 +77,12 @@ export class UCDStoreNotInitializedError extends UCDStoreBaseError {
     super("Store is not initialized. Please initialize the store before performing operations.");
     this.name = "UCDStoreNotInitializedError";
   }
-
-  "~toStoreError"() {
-    return {
-      type: "NOT_INITIALIZED" as const,
-      message: this.message,
-    };
-  }
 }
 
-export type GenericError = ReturnType<UCDStoreError["~toStoreError"]>;
-export type FileNotFoundError = ReturnType<UCDStoreFileNotFoundError["~toStoreError"]>;
-export type UnsupportedVersionError = ReturnType<UCDStoreVersionNotFoundError["~toStoreError"]>;
-export type BridgeUnsupportedOperationError = ReturnType<UCDStoreBridgeUnsupportedOperation["~toStoreError"]>;
-export type InvalidManifestError = ReturnType<UCDStoreInvalidManifestError["~toStoreError"]>;
-export type StoreNotInitializedError = ReturnType<UCDStoreNotInitializedError["~toStoreError"]>;
-
 export type StoreError
-  = | GenericError
-    | FileNotFoundError
-    | UnsupportedVersionError
-    | BridgeUnsupportedOperationError
-    | InvalidManifestError
-    | StoreNotInitializedError;
+  = | UCDStoreGenericError
+    | UCDStoreFileNotFoundError
+    | UCDStoreVersionNotFoundError
+    | UCDStoreBridgeUnsupportedOperation
+    | UCDStoreInvalidManifestError
+    | UCDStoreNotInitializedError;

--- a/packages/ucd-store/src/index.ts
+++ b/packages/ucd-store/src/index.ts
@@ -1,5 +1,5 @@
 export {
-  UCDStoreError,
+  UCDStoreGenericError as UCDStoreError,
   UCDStoreFileNotFoundError,
   UCDStoreBridgeUnsupportedOperation as UCDStoreUnsupportedFeature,
   UCDStoreVersionNotFoundError,

--- a/packages/ucd-store/src/index.ts
+++ b/packages/ucd-store/src/index.ts
@@ -1,6 +1,6 @@
 export {
-  UCDStoreGenericError as UCDStoreError,
   UCDStoreFileNotFoundError,
+  UCDStoreGenericError,
   UCDStoreBridgeUnsupportedOperation as UCDStoreUnsupportedFeature,
   UCDStoreVersionNotFoundError,
 } from "./errors";

--- a/packages/ucd-store/src/internal/clean.ts
+++ b/packages/ucd-store/src/internal/clean.ts
@@ -3,7 +3,7 @@ import type { SharedStoreOperationOptions } from "../types";
 import { assertCapability } from "@ucdjs/fs-bridge";
 import { createConcurrencyLimiter } from "@ucdjs/shared";
 import { dirname, join } from "pathe";
-import { UCDStoreError } from "../errors";
+import { UCDStoreGenericError } from "../errors";
 
 export type CleanOptions = SharedStoreOperationOptions;
 
@@ -44,7 +44,7 @@ export async function internal__clean(store: UCDStore, options: internal_CleanOp
 
   // throw if concurrency is less than 1
   if (concurrency < 1) {
-    throw new UCDStoreError("Concurrency must be at least 1");
+    throw new UCDStoreGenericError("Concurrency must be at least 1");
   }
 
   const [analyses, error] = await store.analyze({

--- a/packages/ucd-store/src/internal/files.ts
+++ b/packages/ucd-store/src/internal/files.ts
@@ -1,7 +1,7 @@
 import type { UCDClient } from "@ucdjs/fetch";
 import { isApiError } from "@ucdjs/fetch";
 import { flattenFilePaths } from "@ucdjs/shared";
-import { UCDStoreError } from "../errors";
+import { UCDStoreGenericError } from "../errors";
 
 /**
  * Retrieves the expected file paths for a specific Unicode version from the API.
@@ -15,7 +15,7 @@ import { UCDStoreError } from "../errors";
  * @param {string} version - The Unicode version to get expected file paths for
  * @returns {Promise<string[]>} A promise that resolves to an array of file paths that should exist for the version
  *
- * @throws {UCDStoreError} When the API request fails or returns an error
+ * @throws {UCDStoreGenericError} When the API request fails or returns an error
  */
 export async function getExpectedFilePaths(
   client: UCDClient,
@@ -31,7 +31,7 @@ export async function getExpectedFilePaths(
   });
 
   if (isApiError(error) || error != null || (data == null && error == null)) {
-    throw new UCDStoreError(`Failed to fetch expected files for version '${version}': ${error?.message}`);
+    throw new UCDStoreGenericError(`Failed to fetch expected files for version '${version}': ${error?.message}`);
   }
 
   return flattenFilePaths(data!);

--- a/packages/ucd-store/src/internal/files.ts
+++ b/packages/ucd-store/src/internal/files.ts
@@ -52,6 +52,4 @@ export async function getExpectedFilePaths(
   }
 
   return flattenFilePaths(data);
-
-  return flattenFilePaths(data!);
 }

--- a/packages/ucd-store/src/internal/files.ts
+++ b/packages/ucd-store/src/internal/files.ts
@@ -30,9 +30,28 @@ export async function getExpectedFilePaths(
     },
   });
 
-  if (isApiError(error) || error != null || (data == null && error == null)) {
-    throw new UCDStoreGenericError(`Failed to fetch expected files for version '${version}': ${error?.message}`);
+  if (error != null) {
+    if (!isApiError(error)) {
+      throw new UCDStoreGenericError(
+        `Failed to fetch expected files for version '${version}': ${error}`,
+        { version },
+      );
+    }
+
+    throw new UCDStoreGenericError(
+      `Failed to fetch expected files for version '${version}': ${error.message}`,
+      { version, status: error.status },
+    );
   }
+
+  if (data == null) {
+    throw new UCDStoreGenericError(
+      `Failed to fetch expected files for version '${version}': empty response`,
+      { version },
+    );
+  }
+
+  return flattenFilePaths(data);
 
   return flattenFilePaths(data!);
 }

--- a/packages/ucd-store/src/internal/mirror.ts
+++ b/packages/ucd-store/src/internal/mirror.ts
@@ -5,7 +5,7 @@ import { isApiError } from "@ucdjs/fetch";
 import { assertCapability } from "@ucdjs/fs-bridge";
 import { createConcurrencyLimiter } from "@ucdjs/shared";
 import { dirname, join } from "pathe";
-import { UCDStoreError, UCDStoreVersionNotFoundError } from "../errors";
+import { UCDStoreGenericError, UCDStoreVersionNotFoundError } from "../errors";
 import { getExpectedFilePaths } from "./files";
 
 export interface MirrorOptions extends SharedStoreOperationOptions {
@@ -47,7 +47,7 @@ export async function internal__mirror(store: UCDStore, options: Required<Mirror
   }
 
   if (concurrency < 1) {
-    throw new UCDStoreError("Concurrency must be at least 1");
+    throw new UCDStoreGenericError("Concurrency must be at least 1");
   }
 
   assertCapability(store.fs, ["exists", "mkdir"]);
@@ -142,12 +142,12 @@ async function internal__mirrorFile(store: UCDStore, version: string, filePath: 
   });
 
   if (isApiError(error)) {
-    throw new UCDStoreError(`Failed to fetch file '${filePath}': ${error?.message}`);
+    throw new UCDStoreGenericError(`Failed to fetch file '${filePath}': ${error?.message}`);
   }
 
   const contentTypeHeader = response.headers.get("content-type");
   if (!contentTypeHeader) {
-    throw new UCDStoreError(`Failed to fetch file '${filePath}': No content type header received.`);
+    throw new UCDStoreGenericError(`Failed to fetch file '${filePath}': No content type header received.`);
   }
 
   const semiColonIndex = contentTypeHeader.indexOf(";");

--- a/packages/ucd-store/src/internal/repair.ts
+++ b/packages/ucd-store/src/internal/repair.ts
@@ -4,7 +4,7 @@ import type { AnalyzeResult } from "./analyze";
 import { assertCapability } from "@ucdjs/fs-bridge";
 import { createConcurrencyLimiter } from "@ucdjs/shared";
 import { dirname, join } from "pathe";
-import { UCDStoreError } from "../errors";
+import { UCDStoreGenericError } from "../errors";
 import { internal__analyze } from "./analyze";
 import { internal__clean } from "./clean";
 import { internal__mirror } from "./mirror";
@@ -53,7 +53,7 @@ export async function internal__repair(store: UCDStore, options: Required<Repair
   }
 
   if (concurrency < 1) {
-    throw new UCDStoreError("Concurrency must be at least 1");
+    throw new UCDStoreGenericError("Concurrency must be at least 1");
   }
 
   // analyze store to find what needs repairing

--- a/packages/ucd-store/src/store.ts
+++ b/packages/ucd-store/src/store.ts
@@ -19,6 +19,7 @@ import { createPathFilter, flattenFilePaths, safeJsonParse, tryCatch } from "@uc
 import defu from "defu";
 import { isAbsolute, join } from "pathe";
 import {
+  UCDStoreFileNotFoundError,
   UCDStoreGenericError,
   UCDStoreInvalidManifestError,
   UCDStoreNotInitializedError,
@@ -248,7 +249,7 @@ export class UCDStore {
         return content;
       } catch (err) {
         if (err instanceof Error && err.message.includes("ENOENT")) {
-          throw new UCDStoreGenericError(`File '${filePath}' does not exist in version '${version}'.`);
+          throw new UCDStoreFileNotFoundError(filePath, version);
         }
 
         throw err;

--- a/packages/ucd-store/src/store.ts
+++ b/packages/ucd-store/src/store.ts
@@ -19,7 +19,7 @@ import { createPathFilter, flattenFilePaths, safeJsonParse, tryCatch } from "@uc
 import defu from "defu";
 import { isAbsolute, join } from "pathe";
 import {
-  UCDStoreError,
+  UCDStoreGenericError,
   UCDStoreInvalidManifestError,
   UCDStoreNotInitializedError,
   UCDStoreVersionNotFoundError,
@@ -59,7 +59,7 @@ export class UCDStore {
     });
 
     if (fs == null) {
-      throw new UCDStoreError("FileSystemBridge instance is required to create a UCDStore.");
+      throw new UCDStoreGenericError("FileSystemBridge instance is required to create a UCDStore.");
     }
 
     this.baseUrl = baseUrl;
@@ -233,7 +233,7 @@ export class UCDStore {
       }
 
       if (!this.#filter(filePath, extraFilters)) {
-        throw new UCDStoreError(`File path "${filePath}" is filtered out by the store's filter patterns.`);
+        throw new UCDStoreGenericError(`File path "${filePath}" is filtered out by the store's filter patterns.`);
       }
 
       assertCapability(this.#fs, "read");
@@ -248,7 +248,7 @@ export class UCDStore {
         return content;
       } catch (err) {
         if (err instanceof Error && err.message.includes("ENOENT")) {
-          throw new UCDStoreError(`File '${filePath}' does not exist in version '${version}'.`);
+          throw new UCDStoreGenericError(`File '${filePath}' does not exist in version '${version}'.`);
         }
 
         throw err;
@@ -264,7 +264,7 @@ export class UCDStore {
     // fetch available versions from API to validate
     const { data, error } = await this.#client.GET("/api/v1/versions");
     if (isApiError(error)) {
-      throw new UCDStoreError(`Failed to fetch Unicode versions: ${error.message}`);
+      throw new UCDStoreGenericError(`Failed to fetch Unicode versions: ${error.message}`);
     }
 
     let hasVersionManifestChanged = false;
@@ -300,7 +300,7 @@ export class UCDStore {
 
     // validate all versions exist in API
     if (!this.#versions.every((v) => availableVersions.includes(v))) {
-      throw new UCDStoreError("Some requested versions are not available in the API");
+      throw new UCDStoreGenericError("Some requested versions are not available in the API");
     }
 
     if (!dryRun) {
@@ -475,7 +475,7 @@ export class UCDStore {
     const manifestData = await this.#fs.read(this.#manifestPath);
 
     if (!manifestData) {
-      throw new UCDStoreError(`Store manifest not found at ${this.#manifestPath}`);
+      throw new UCDStoreGenericError(`Store manifest not found at ${this.#manifestPath}`);
     }
 
     const jsonData = safeJsonParse(manifestData);

--- a/packages/ucd-store/test/analyze.test.ts
+++ b/packages/ucd-store/test/analyze.test.ts
@@ -4,7 +4,7 @@ import { setupMockStore } from "#internal/test-utils/store";
 import { UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
 import { UCDJS_API_BASE_URL } from "@ucdjs/env";
 import { assertCapability } from "@ucdjs/fs-bridge";
-import { UCDStoreError, UCDStoreVersionNotFoundError } from "@ucdjs/ucd-store";
+import { UCDStoreGenericError, UCDStoreVersionNotFoundError } from "@ucdjs/ucd-store";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { testdir } from "vitest-testdirs";
 import { createHTTPUCDStore, createNodeUCDStore, createUCDStore } from "../src/factory";
@@ -287,7 +287,7 @@ describe("analyze operations", () => {
 
       expect(analyses).toBeNull();
       assert(error != null, "Expected error to be non-null");
-      expect(error).toBeInstanceOf(UCDStoreError);
+      expect(error).toBeInstanceOf(UCDStoreGenericError);
     });
   });
 

--- a/packages/ucd-store/test/errors.test.ts
+++ b/packages/ucd-store/test/errors.test.ts
@@ -3,55 +3,40 @@ import { describe, expect, it } from "vitest";
 import {
   UCDStoreBaseError,
   UCDStoreBridgeUnsupportedOperation,
-  UCDStoreError,
   UCDStoreFileNotFoundError,
+  UCDStoreGenericError,
   UCDStoreInvalidManifestError,
   UCDStoreNotInitializedError,
   UCDStoreVersionNotFoundError,
 } from "../src/errors";
 
 describe("custom errors", () => {
-  describe("UCDStoreError", () => {
+  describe("UCDStoreGenericError", () => {
     it("should create an instance with the correct message", () => {
       const message = "Test error message";
-      const error = new UCDStoreError(message);
+      const error = new UCDStoreGenericError(message);
 
       expect(error.message).toBe(message);
     });
 
     it("should extend Error class and have correct properties", () => {
-      const error = new UCDStoreError("Test message");
+      const error = new UCDStoreGenericError("Test message");
 
       expect(error).toBeInstanceOf(Error);
       expect(error).toBeInstanceOf(UCDStoreBaseError);
-      expect(error).toBeInstanceOf(UCDStoreError);
-      expect(error.name).toBe("UCDStoreError");
+      expect(error).toBeInstanceOf(UCDStoreGenericError);
+      expect(error.name).toBe("UCDStoreGenericError");
       expect(error.stack).toBeDefined();
-      expect(error.stack).toContain("UCDStoreError");
+      expect(error.stack).toContain("UCDStoreGenericError");
     });
 
-    it("should convert to store error format correctly", () => {
-      const message = "Test error message";
-      const error = new UCDStoreError(message);
-      const storeError = error["~toStoreError"]();
-
-      expect(storeError).toEqual({
-        type: "GENERIC",
-        message,
-      });
-    });
-
-    it("should convert to store error format with data", () => {
+    it("should accept data parameter", () => {
       const message = "Test error with data";
       const data = { code: 500, details: "Something went wrong" };
-      const error = new UCDStoreError(message, data);
-      const storeError = error["~toStoreError"]();
+      const error = new UCDStoreGenericError(message, data);
 
-      expect(storeError).toEqual({
-        type: "GENERIC",
-        message,
-        data,
-      });
+      expect(error.message).toBe(message);
+      expect(error.data).toEqual(data);
     });
   });
 
@@ -92,19 +77,6 @@ describe("custom errors", () => {
       expect(error).toBeInstanceOf(UCDStoreBaseError);
       expect(error).toBeInstanceOf(UCDStoreVersionNotFoundError);
       expect(error.name).toBe("UCDStoreVersionNotFoundError");
-      expect(error.message).toBe(`Version '${version}' does not exist in the store.`);
-      expect(error.version).toBe(version);
-    });
-
-    it.each([
-      "15.0.0",
-      "14.0.0",
-      "1.0",
-      "2.0.0",
-      "3.0.0-beta",
-      "4.0.0-alpha.1",
-    ])("should format message correctly for version %s", (version) => {
-      const error = new UCDStoreVersionNotFoundError(version);
       expect(error.message).toBe(`Version '${version}' does not exist in the store.`);
       expect(error.version).toBe(version);
     });
@@ -185,17 +157,12 @@ describe("custom errors", () => {
       expect(error.message).toBe(`invalid manifest at ${manifestPath}: ${message}`);
     });
 
-    it("should convert to store error format correctly", () => {
+    it("should format error message correctly", () => {
       const manifestPath = "/store/.ucd-store.json";
       const message = "schema validation failed";
       const error = new UCDStoreInvalidManifestError(manifestPath, message);
-      const storeError = error["~toStoreError"]();
 
-      expect(storeError).toEqual({
-        type: "INVALID_MANIFEST",
-        manifestPath,
-        message: `invalid manifest at ${manifestPath}: ${message}`,
-      });
+      expect(error.message).toBe(`invalid manifest at ${manifestPath}: ${message}`);
     });
 
     it.each([
@@ -207,11 +174,6 @@ describe("custom errors", () => {
       const error = new UCDStoreInvalidManifestError(manifestPath, message);
 
       expect(error.message).toBe(`invalid manifest at ${manifestPath}: ${message}`);
-
-      const storeError = error["~toStoreError"]();
-      expect(storeError.type).toBe("INVALID_MANIFEST");
-      expect(storeError.manifestPath).toBe(manifestPath);
-      expect(storeError.message).toBe(`invalid manifest at ${manifestPath}: ${message}`);
     });
   });
 
@@ -226,32 +188,11 @@ describe("custom errors", () => {
       expect(error.message).toBe("Store is not initialized. Please initialize the store before performing operations.");
     });
 
-    it("should convert to store error format correctly", () => {
-      const error = new UCDStoreNotInitializedError();
-      const storeError = error["~toStoreError"]();
-
-      expect(storeError).toEqual({
-        type: "NOT_INITIALIZED",
-        message: "Store is not initialized. Please initialize the store before performing operations.",
-      });
-    });
-
     it("should have consistent error message across multiple instances", () => {
       const error1 = new UCDStoreNotInitializedError();
       const error2 = new UCDStoreNotInitializedError();
 
       expect(error1.message).toBe(error2.message);
-
-      const storeError1 = error1["~toStoreError"]();
-      const storeError2 = error2["~toStoreError"]();
-
-      expect(storeError1).toEqual(storeError2);
-    });
-
-    it("should not accept any parameters in constructor", () => {
-      const error = new UCDStoreNotInitializedError();
-      expect(error).toBeDefined();
-      expect(error.message).toBe("Store is not initialized. Please initialize the store before performing operations.");
     });
   });
 });

--- a/packages/ucd-store/test/file-operations.test.ts
+++ b/packages/ucd-store/test/file-operations.test.ts
@@ -726,7 +726,7 @@ describe("file operations", () => {
       const [fileData, fileError] = await store.getFile("15.0.0", "./nonexistent.txt");
       expect(fileData).toBe(null);
       assert(fileError != null, "Expected error for nonexistent file");
-      expect(fileError.message).toBe("File './nonexistent.txt' does not exist in version '15.0.0'.");
+      expect(fileError.message).toBe("File not found: ./nonexistent.txt in version 15.0.0");
     });
 
     it("should disallow reading files outside the store", async () => {

--- a/packages/ucd-store/test/internal/files.test.ts
+++ b/packages/ucd-store/test/internal/files.test.ts
@@ -50,7 +50,7 @@ describe("getExpectedFilePaths", () => {
     ]);
   });
 
-  it("should throw UCDStoreError when API returns error", async () => {
+  it("should throw UCDStoreGenericError when API returns error", async () => {
     mockFetch([
       ["GET", `${UCDJS_API_BASE_URL}/api/v1/versions/:version/file-tree`, () => {
         return HttpResponse.json({

--- a/packages/ucd-store/test/internal/files.test.ts
+++ b/packages/ucd-store/test/internal/files.test.ts
@@ -3,7 +3,7 @@ import { HttpResponse, mockFetch } from "#internal/test-utils/msw";
 import { UCDJS_API_BASE_URL } from "@ucdjs/env";
 import { client } from "@ucdjs/fetch";
 import { describe, expect, it } from "vitest";
-import { UCDStoreError } from "../../src/errors";
+import { UCDStoreGenericError } from "../../src/errors";
 import { getExpectedFilePaths } from "../../src/internal/files";
 
 describe("getExpectedFilePaths", () => {
@@ -63,7 +63,7 @@ describe("getExpectedFilePaths", () => {
 
     await expect(
       getExpectedFilePaths(client, "15.0.0"),
-    ).rejects.toThrow(UCDStoreError);
+    ).rejects.toThrow(UCDStoreGenericError);
   });
 
   it("should handle empty file tree", async () => {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to UCDJS!
----------------------------------------------------------------------->
* Updated all references from `UCDStoreError` to `UCDStoreGenericError` across the codebase.
* Removed the `~toStoreError` method from error classes to simplify error handling.
* Adjusted tests to reflect the changes in error naming and structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Error handling simplified to class-based error types with clearer messages and a unified StoreError union.
  - Introduced a generic error class that accepts an optional data payload and exposes relevant fields for file/version cases.

- Breaking Changes
  - Removed the toStoreError conversion from the public API.
  - The generic error class is now the primary exported error (kept aliased for compatibility).

- Tests
  - Tests updated to use and validate the new error classes, names, and properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->