### PR TITLE
feat(fs-bridge): add new custom errors

### DIFF
--- a/.changeset/long-toys-guess.md
+++ b/.changeset/long-toys-guess.md
@@ -1,0 +1,26 @@
+---
+"@ucdjs/fs-bridge": minor
+---
+
+feat: add custom fs-bridge errors
+
+Adds four new custom error classes for better error handling in the fs-bridge:
+
+- `BridgeGenericError`: For wrapping unexpected errors with optional original error reference
+- `BridgePathTraversal`: For path traversal security violations when accessing files outside allowed scope
+- `BridgeFileNotFound`: For file or directory not found errors
+- `BridgeEntryIsDir`: For cases where a file is expected but a directory is found
+
+```typescript
+import { BridgeFileNotFound, BridgePathTraversal } from '@ucdjs/fs-bridge';
+
+// Example usage in bridge implementations
+try {
+  await fsp.readFile(path);
+} catch (error) {
+  if (error.code === 'ENOENT') {
+    throw new BridgeFileNotFound(path);
+  }
+  throw new BridgeGenericError('Unexpected file system error', error);
+}
+```

--- a/packages/fs-bridge/src/assertions.ts
+++ b/packages/fs-bridge/src/assertions.ts
@@ -1,4 +1,5 @@
 import type { FileSystemBridge, FileSystemBridgeCapabilityKey } from "./types";
+import { BridgeUnsupportedOperation } from "./errors";
 
 /**
  * Asserts that a file system bridge supports the specified capability or capabilities.
@@ -23,17 +24,5 @@ export function assertCapability<T extends FileSystemBridgeCapabilityKey = never
     if (!bridge.capabilities[capability]) {
       throw new BridgeUnsupportedOperation(capability);
     }
-  }
-}
-
-export class BridgeUnsupportedOperation extends Error {
-  public readonly capability: FileSystemBridgeCapabilityKey;
-
-  constructor(
-    capability: FileSystemBridgeCapabilityKey,
-  ) {
-    super(`File system bridge does not support the '${capability}' capability.`);
-    this.name = "BridgeUnsupportedOperation";
-    this.capability = capability;
   }
 }

--- a/packages/fs-bridge/src/define.ts
+++ b/packages/fs-bridge/src/define.ts
@@ -6,7 +6,7 @@ import type {
   FileSystemBridgeOperations,
 } from "./types";
 import { z } from "zod";
-import { BridgeUnsupportedOperation } from "./assertions";
+import { BridgeUnsupportedOperation } from "./errors";
 
 export function defineFileSystemBridge<
   TOptionsSchema extends z.ZodType,

--- a/packages/fs-bridge/src/errors.ts
+++ b/packages/fs-bridge/src/errors.ts
@@ -11,3 +11,43 @@ export class BridgeUnsupportedOperation extends Error {
     this.capability = capability;
   }
 }
+
+export class BridgeGenericError extends Error {
+  public readonly originalError?: Error;
+
+  constructor(message: string, originalError?: Error) {
+    super(message);
+    this.name = "BridgeGenericError";
+    this.originalError = originalError;
+  }
+}
+
+export class BridgePathTraversal extends Error {
+  public readonly path: string;
+
+  constructor(path: string) {
+    super(`Path traversal detected: attempted to access path outside of allowed scope: ${path}`);
+    this.name = "BridgePathTraversal";
+    this.path = path;
+  }
+}
+
+export class BridgeFileNotFound extends Error {
+  public readonly path: string;
+
+  constructor(path: string) {
+    super(`File or directory not found: ${path}`);
+    this.name = "BridgeFileNotFound";
+    this.path = path;
+  }
+}
+
+export class BridgeEntryIsDir extends Error {
+  public readonly path: string;
+
+  constructor(path: string) {
+    super(`Expected file but found directory: ${path}`);
+    this.name = "BridgeEntryIsDir";
+    this.path = path;
+  }
+}

--- a/packages/fs-bridge/src/errors.ts
+++ b/packages/fs-bridge/src/errors.ts
@@ -1,0 +1,13 @@
+import type { FileSystemBridgeCapabilityKey } from "./types";
+
+export class BridgeUnsupportedOperation extends Error {
+  public readonly capability: FileSystemBridgeCapabilityKey;
+
+  constructor(
+    capability: FileSystemBridgeCapabilityKey,
+  ) {
+    super(`File system bridge does not support the '${capability}' capability.`);
+    this.name = "BridgeUnsupportedOperation";
+    this.capability = capability;
+  }
+}

--- a/packages/fs-bridge/src/index.ts
+++ b/packages/fs-bridge/src/index.ts
@@ -1,5 +1,11 @@
-export { assertCapability, BridgeUnsupportedOperation } from "./assertions";
+export {
+  assertCapability,
+} from "./assertions";
+
 export { defineFileSystemBridge } from "./define";
+
+export * from "./errors";
+
 export type {
   FileSystemBridge,
   FileSystemBridgeOperations,


### PR DESCRIPTION
### 🔗 Linked issue

resolves #227 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR adds new errors to the fs-bridge. None of the errors are currently in use except for the `BridgeUnsupportedOperation`.

They will be integrated in the PR for the following issues: #225 #226 

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to UCDJS!
----------------------------------------------------------------------->
