### PR TITLE
feat(fs-bridge): wrap bridge operations in try-catch

### DIFF
--- a/.changeset/silver-webs-knock.md
+++ b/.changeset/silver-webs-knock.md
@@ -14,7 +14,7 @@ Wraps all fs-bridge operation methods with automatic error handling to improve e
 ```typescript
 import { defineFileSystemBridge, BridgeFileNotFound, BridgeGenericError } from '@ucdjs/fs-bridge';
 
-const bridge = defineFileSystemBridge({
+const bridgeCreator = defineFileSystemBridge({
   setup() {
     return {
       async read(path) {
@@ -30,6 +30,8 @@ const bridge = defineFileSystemBridge({
     };
   }
 });
+
+const bridge = bridgeCreator();
 
 // Usage - all errors are now consistently handled
 try {

--- a/.changeset/silver-webs-knock.md
+++ b/.changeset/silver-webs-knock.md
@@ -12,7 +12,7 @@ Wraps all fs-bridge operation methods with automatic error handling to improve e
 - **Transparent to implementations**: Bridge implementations don't need to change - error handling is applied automatically
 
 ```typescript
-import { defineFileSystemBridge, BridgeFileNotFound } from '@ucdjs/fs-bridge';
+import { defineFileSystemBridge, BridgeFileNotFound, BridgeGenericError } from '@ucdjs/fs-bridge';
 
 const bridge = defineFileSystemBridge({
   setup() {

--- a/.changeset/silver-webs-knock.md
+++ b/.changeset/silver-webs-knock.md
@@ -1,0 +1,45 @@
+---
+"@ucdjs/fs-bridge": minor
+"@ucdjs/ucd-store": minor
+---
+
+feat: add error handling wrapper to fs-bridge operations
+
+Wraps all fs-bridge operation methods with automatic error handling to improve error management:
+
+- **Preserves custom bridge errors**: Re-throws `BridgeBaseError` instances (like `BridgePathTraversal`, `BridgeFileNotFound`) directly
+- **Wraps unexpected errors**: Converts unknown/system errors into `BridgeGenericError` with operation context
+- **Transparent to implementations**: Bridge implementations don't need to change - error handling is applied automatically
+
+```typescript
+import { defineFileSystemBridge, BridgeFileNotFound } from '@ucdjs/fs-bridge';
+
+const bridge = defineFileSystemBridge({
+  setup() {
+    return {
+      async read(path) {
+        // If this throws a custom bridge error, it's re-thrown as-is
+        if (!pathExists(path)) {
+          throw new BridgeFileNotFound(path);
+        }
+        
+        // If this throws an unexpected error (like network timeout),
+        // it gets wrapped in BridgeGenericError with context
+        return await fetchFile(path);
+      }
+    };
+  }
+});
+
+// Usage - all errors are now consistently handled
+try {
+  await bridge.read('/some/path');
+} catch (error) {
+  if (error instanceof BridgeFileNotFound) {
+    // Handle specific bridge error
+  } else if (error instanceof BridgeGenericError) {
+    // Handle wrapped unexpected error
+    console.log(error.originalError); // Access the original error
+  }
+}
+```

--- a/packages/fs-bridge/src/define.ts
+++ b/packages/fs-bridge/src/define.ts
@@ -51,7 +51,7 @@ export function defineFileSystemBridge<
             };
           }
 
-          const originalMethod = target[property as keyof typeof target] as (...args: any[]) => any;
+          const originalMethod = target[property as keyof typeof target] as (...args: unknown[]) => unknown;
 
           if (typeof originalMethod === "function") {
             return (...args: any[]) => {
@@ -59,8 +59,8 @@ export function defineFileSystemBridge<
                 const result = originalMethod.apply(target, args);
 
                 // check if result is a promise
-                if (result && typeof result.then === "function") {
-                  return result.catch((err: unknown) => handleError(property, err));
+                if (result && typeof (result as PromiseLike<unknown>)?.then === "function") {
+                  return (result as Promise<unknown>)?.catch((err: unknown) => handleError(property, err));
                 }
 
                 // sync result, return as-is

--- a/packages/fs-bridge/src/define.ts
+++ b/packages/fs-bridge/src/define.ts
@@ -56,7 +56,7 @@ export function defineFileSystemBridge<
 
           if (typeof originalMethod === "function") {
             return (...args: any[]) => {
-              return originalMethod(...args)
+              return originalMethod.apply(target, args)
                 .catch((error: unknown) => {
                   // re-throw custom bridge errors directly
                   if (error instanceof BridgeBaseError) {

--- a/packages/fs-bridge/src/define.ts
+++ b/packages/fs-bridge/src/define.ts
@@ -6,7 +6,7 @@ import type {
   FileSystemBridgeOperations,
 } from "./types";
 import { z } from "zod";
-import { BridgeUnsupportedOperation } from "./errors";
+import { BridgeBaseError, BridgeGenericError, BridgeUnsupportedOperation } from "./errors";
 
 export function defineFileSystemBridge<
   TOptionsSchema extends z.ZodType,
@@ -34,18 +34,39 @@ export function defineFileSystemBridge<
 
     const capabilities = inferCapabilitiesFromOperations(bridge);
 
-    // create a proxy that throws for unsupported operations
+    // create a proxy that throws for unsupported operations and wraps methods in try-catch
     const proxiedBridge = new Proxy(bridge, {
       get(target, prop) {
         if (prop === "capabilities") {
           return capabilities;
         }
 
-        // If it's an operation method and not implemented, throw
+        // if it's an operation method and not implemented, throw
         if (typeof prop === "string" && prop in capabilities) {
           if (!target[prop as keyof typeof target]) {
             return () => {
               throw new BridgeUnsupportedOperation(prop as FileSystemBridgeCapabilityKey);
+            };
+          }
+
+          // eslint-disable-next-line ts/no-unsafe-function-type
+          const originalMethod = target[prop as keyof typeof target] as Function;
+
+          if (typeof originalMethod === "function") {
+            return (...args: any[]) => {
+              return originalMethod(...args)
+                .catch((error: unknown) => {
+                  // re-throw custom bridge errors directly
+                  if (error instanceof BridgeBaseError) {
+                    throw error;
+                  }
+
+                  // wrap unexpected errors in BridgeGenericError
+                  throw new BridgeGenericError(
+                    `Unexpected error in ${prop} operation: ${error instanceof Error ? error.message : String(error)}`,
+                    error instanceof Error ? error : undefined,
+                  );
+                });
             };
           }
         }

--- a/packages/fs-bridge/src/define.ts
+++ b/packages/fs-bridge/src/define.ts
@@ -30,7 +30,7 @@ export function defineFileSystemBridge<
 
     const bridge = fsBridge.setup({
       options,
-      state: state ?? {} as TState,
+      state: (state ?? {}) as TState,
       resolveSafePath,
     });
 

--- a/packages/fs-bridge/src/define.ts
+++ b/packages/fs-bridge/src/define.ts
@@ -51,8 +51,7 @@ export function defineFileSystemBridge<
             };
           }
 
-          // eslint-disable-next-line ts/no-unsafe-function-type
-          const originalMethod = target[property as keyof typeof target] as Function;
+          const originalMethod = target[property as keyof typeof target] as (...args: any[]) => any;
 
           if (typeof originalMethod === "function") {
             return (...args: any[]) => {

--- a/packages/fs-bridge/src/errors.ts
+++ b/packages/fs-bridge/src/errors.ts
@@ -1,6 +1,13 @@
 import type { FileSystemBridgeCapabilityKey } from "./types";
 
-export class BridgeUnsupportedOperation extends Error {
+export abstract class BridgeBaseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BridgeBaseError";
+  }
+}
+
+export class BridgeUnsupportedOperation extends BridgeBaseError {
   public readonly capability: FileSystemBridgeCapabilityKey;
 
   constructor(
@@ -12,7 +19,7 @@ export class BridgeUnsupportedOperation extends Error {
   }
 }
 
-export class BridgeGenericError extends Error {
+export class BridgeGenericError extends BridgeBaseError {
   public readonly originalError?: Error;
 
   constructor(message: string, originalError?: Error) {
@@ -22,7 +29,7 @@ export class BridgeGenericError extends Error {
   }
 }
 
-export class BridgePathTraversal extends Error {
+export class BridgePathTraversal extends BridgeBaseError {
   public readonly path: string;
 
   constructor(path: string) {
@@ -32,7 +39,7 @@ export class BridgePathTraversal extends Error {
   }
 }
 
-export class BridgeFileNotFound extends Error {
+export class BridgeFileNotFound extends BridgeBaseError {
   public readonly path: string;
 
   constructor(path: string) {
@@ -42,7 +49,7 @@ export class BridgeFileNotFound extends Error {
   }
 }
 
-export class BridgeEntryIsDir extends Error {
+export class BridgeEntryIsDir extends BridgeBaseError {
   public readonly path: string;
 
   constructor(path: string) {

--- a/packages/fs-bridge/src/errors.ts
+++ b/packages/fs-bridge/src/errors.ts
@@ -1,9 +1,21 @@
 import type { FileSystemBridgeCapabilityKey } from "./types";
 
 export abstract class BridgeBaseError extends Error {
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
     this.name = "BridgeBaseError";
+  }
+}
+
+export class BridgeGenericError extends BridgeBaseError {
+  public readonly originalError?: Error;
+
+  constructor(message: string, originalError?: Error) {
+    super(message, {
+      cause: originalError,
+    });
+    this.name = "BridgeGenericError";
+    this.originalError = originalError;
   }
 }
 
@@ -16,16 +28,6 @@ export class BridgeUnsupportedOperation extends BridgeBaseError {
     super(`File system bridge does not support the '${capability}' capability.`);
     this.name = "BridgeUnsupportedOperation";
     this.capability = capability;
-  }
-}
-
-export class BridgeGenericError extends BridgeBaseError {
-  public readonly originalError?: Error;
-
-  constructor(message: string, originalError?: Error) {
-    super(message);
-    this.name = "BridgeGenericError";
-    this.originalError = originalError;
   }
 }
 

--- a/packages/fs-bridge/src/index.ts
+++ b/packages/fs-bridge/src/index.ts
@@ -1,6 +1,4 @@
-export {
-  assertCapability,
-} from "./assertions";
+export { assertCapability } from "./assertions";
 
 export { defineFileSystemBridge } from "./define";
 

--- a/packages/ucd-store/src/errors.ts
+++ b/packages/ucd-store/src/errors.ts
@@ -6,8 +6,6 @@ export abstract class UCDStoreBaseError extends Error {
     super(message);
     this.name = "UCDStoreBaseError";
   }
-
-  // prevents throwing this
 }
 
 export class UCDStoreGenericError extends UCDStoreBaseError {


### PR DESCRIPTION
### 🔗 Linked issue

resolves #226 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to UCDJS!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automatic error handling for file-system bridge operations: known bridge errors pass through; unexpected errors are wrapped with clearer, contextual messages that preserve the original cause.

- Refactor
  - Unified error hierarchy under a common base for more consistent error reporting across bridges.

- Chores
  - Updated dependencies to minor releases for stability and compatibility.

- Style
  - Minor export formatting and comment cleanup with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->