### PR TITLE
refactor(path-utils): remove unc support

### DIFF
--- a/packages/path-utils/src/errors.ts
+++ b/packages/path-utils/src/errors.ts
@@ -36,29 +36,6 @@ export class WindowsDriveMismatchError extends PathUtilsBaseError {
   }
 }
 
-export class WindowsPathTypeMismatchError extends PathUtilsBaseError {
-  public readonly basePathType: string;
-  public readonly inputPathType: string;
-
-  constructor(basePathType: string, inputPathType: string) {
-    super(`Cannot combine ${inputPathType} path with ${basePathType} base path on Windows`);
-    this.name = "WindowsPathTypeMismatchError";
-    this.basePathType = basePathType;
-    this.inputPathType = inputPathType;
-  }
-}
-
-export class WindowsUNCShareMismatchError extends PathUtilsBaseError {
-  public readonly baseShare: string;
-  public readonly inputShare: string;
-
-  constructor(baseShare: string, inputShare: string) {
-    super(`Different UNC shares not allowed: base share '${baseShare}' differs from input share '${inputShare}'`);
-    this.name = "WindowsUNCShareMismatchError";
-    this.baseShare = baseShare;
-    this.inputShare = inputShare;
-  }
-}
 
 export class FailedToDecodePathError extends PathUtilsBaseError {
   constructor() {

--- a/packages/path-utils/src/errors.ts
+++ b/packages/path-utils/src/errors.ts
@@ -36,7 +36,6 @@ export class WindowsDriveMismatchError extends PathUtilsBaseError {
   }
 }
 
-
 export class FailedToDecodePathError extends PathUtilsBaseError {
   constructor() {
     super("Failed to decode path");

--- a/packages/path-utils/src/errors.ts
+++ b/packages/path-utils/src/errors.ts
@@ -80,3 +80,13 @@ export class WindowsPathBehaviorNotImplementedError extends PathUtilsBaseError {
     this.name = "WindowsPathBehaviorNotImplementedError";
   }
 }
+
+export class UNCPathNotSupportedError extends PathUtilsBaseError {
+  public readonly path: string;
+
+  constructor(path: string) {
+    super(`UNC paths are not supported: '${path}'`);
+    this.name = "UNCPathNotSupportedError";
+    this.path = path;
+  }
+}

--- a/packages/path-utils/src/index.ts
+++ b/packages/path-utils/src/index.ts
@@ -4,19 +4,18 @@ export {
   MaximumDecodingIterationsExceededError,
   PathTraversalError,
   PathUtilsBaseError,
+  UNCPathNotSupportedError,
   WindowsDriveMismatchError,
   WindowsPathBehaviorNotImplementedError,
   WindowsPathTypeMismatchError,
-  WindowsUNCShareMismatchError,
 } from "./errors";
 
 export {
-  getAnyUNCRoot,
+  assertNotUNCPath,
   getWindowsDriveLetter,
   isUNCPath,
   isWindowsDrivePath,
   stripDriveLetter,
-  toUNCPosix,
   toUnixFormat,
 } from "./platform";
 

--- a/packages/path-utils/src/index.ts
+++ b/packages/path-utils/src/index.ts
@@ -7,7 +7,6 @@ export {
   UNCPathNotSupportedError,
   WindowsDriveMismatchError,
   WindowsPathBehaviorNotImplementedError,
-  WindowsPathTypeMismatchError,
 } from "./errors";
 
 export {

--- a/packages/path-utils/src/platform.ts
+++ b/packages/path-utils/src/platform.ts
@@ -93,4 +93,3 @@ export function toUnixFormat(inputPath: string): string {
 
   return trimTrailingSlash(pathe.normalize(normalized));
 }
-

--- a/packages/path-utils/src/platform.ts
+++ b/packages/path-utils/src/platform.ts
@@ -6,6 +6,7 @@ import {
   WINDOWS_DRIVE_RE,
   WINDOWS_UNC_ROOT_RE,
 } from "./constants";
+import { UNCPathNotSupportedError } from "./errors";
 
 /**
  * Extracts the Windows drive letter from a given string, if present.
@@ -40,6 +41,9 @@ export function stripDriveLetter(path: string): string {
     throw new TypeError("Path must be a string");
   }
 
+  // Reject UNC paths early
+  assertNotUNCPath(path);
+
   // remove the Windows drive letter (e.g., "C:") from the start of the path
   return path.replace(WINDOWS_DRIVE_RE, "");
 }
@@ -50,7 +54,18 @@ export function stripDriveLetter(path: string): string {
  * @returns {boolean} True if the path is a UNC path, false otherwise.
  */
 export function isUNCPath(path: string): boolean {
-  return WINDOWS_UNC_ROOT_RE.test(path) || (path.startsWith("//") && getAnyUNCRoot(path) !== null);
+  return WINDOWS_UNC_ROOT_RE.test(path) || path.startsWith("//");
+}
+
+/**
+ * Asserts that the given path is not a UNC path. Throws UNCPathNotSupportedError if it is.
+ * @param {string} path - The path to check.
+ * @throws {UNCPathNotSupportedError} If the path is a UNC path.
+ */
+export function assertNotUNCPath(path: string): void {
+  if (isUNCPath(path)) {
+    throw new UNCPathNotSupportedError(path);
+  }
 }
 
 /**
@@ -67,16 +82,10 @@ export function toUnixFormat(inputPath: string): string {
     return "/";
   }
 
+  // Reject UNC paths early
+  assertNotUNCPath(inputPath);
+
   let normalized = pathe.normalize(inputPath.trim());
-
-  // pathe already converts to forward slashes, so we mainly need to handle:
-  // 1. UNC paths (already become //server/share/path)
-  // 2. Drive letters that pathe might preserve
-
-  // check if this is a UNC path (starts with //)
-  if (isUNCPath(inputPath)) {
-    return trimTrailingSlash(normalized);
-  }
 
   // strip driver letters from the normalized string
   normalized = normalized.replace(WINDOWS_DRIVE_LETTER_EVERYWHERE_RE, "");
@@ -85,53 +94,3 @@ export function toUnixFormat(inputPath: string): string {
   return trimTrailingSlash(pathe.normalize(normalized));
 }
 
-/**
- * Extracts the UNC (Universal Naming Convention) root from a given string, if present.
- * @param {string} str - The input string to check for a UNC root.
- * @returns {string | null} The UNC root in the format "//server/share" if found, otherwise null.
- */
-export function getAnyUNCRoot(str: string): string | null {
-  if (!str || str.length < 5) return null;
-  if (!str.startsWith("\\\\") && !str.startsWith("//")) return null;
-
-  const match = str.match(/^(\\\\|\/\/)([^\\/]+)[\\/]([^\\/]+)/);
-  return match ? `//${match[2]}/${match[3]}` : null;
-}
-
-/**
- * Converts Windows UNC paths to Unix-style (POSIX) UNC paths
- * @param {string} inputPath - The UNC path to convert
- * @returns {string | null} Unix-style UNC path or null if not a valid UNC path
- */
-export function toUNCPosix(inputPath: string): string | null {
-  if (typeof inputPath !== "string") {
-    throw new TypeError("Input path must be a string");
-  }
-
-  if (!inputPath || inputPath.trim() === "") {
-    return null;
-  }
-
-  const trimmed = inputPath.trim();
-
-  // check if it's a UNC path (starts with \\ or //)
-  if (!trimmed.startsWith("\\\\") && !trimmed.startsWith("//")) {
-    return null;
-  }
-
-  const normalized = pathe.normalize(trimmed);
-
-  // pathe converts \\server\share to //server/share
-  // but we need to ensure it starts with exactly //
-  if (!normalized.startsWith("//")) {
-    return null;
-  }
-
-  // validate that we have at least server and share
-  const parts = normalized.split("/").filter((part) => part !== "");
-  if (parts.length < 2) {
-    return null;
-  }
-
-  return trimTrailingSlash(normalized);
-}

--- a/packages/path-utils/src/security.ts
+++ b/packages/path-utils/src/security.ts
@@ -33,6 +33,10 @@ export function isWithinBase(resolvedPath: string, basePath: string): boolean {
     return false;
   }
 
+  // Check for UNC paths and reject them early
+  assertNotUNCPath(resolvedPath.trim());
+  assertNotUNCPath(basePath.trim());
+
   // we apply leading slashes after we have verified that the inputs isn't empty.
   basePath = prependLeadingSlash(basePath.trim());
   resolvedPath = prependLeadingSlash(resolvedPath.trim());
@@ -128,7 +132,6 @@ export function resolveSafePath(basePath: string, inputPath: string): string {
     throw new IllegalCharacterInPathError(illegalChar);
   }
 
-
   let resolvedPath: string;
 
   const absoluteInputPath = pathe.resolve(decodedPath);
@@ -165,14 +168,6 @@ export function resolveSafePath(basePath: string, inputPath: string): string {
 
   // If either the process.platform is win32, or we are a case insensitive platform, that isn't darwin.
   const isWindows = osPlatform === "win32" || (!isCaseSensitive && osPlatform !== "darwin");
-
-  console.error({
-    basePath,
-    decodedPath,
-    normalizedBasePath,
-    isWindows,
-    "WINDOWS_DRIVE_RE.test": WINDOWS_DRIVE_RE.test(decodedPath),
-  });
 
   if (isWindows && isWindowsDrivePath(decodedPath)) {
     return internal_resolveWindowsPath(basePath, decodedPath);

--- a/packages/path-utils/test/platform.test.ts
+++ b/packages/path-utils/test/platform.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
-  getAnyUNCRoot,
+  assertNotUNCPath,
   getWindowsDriveLetter,
   isUNCPath,
   isWindowsDrivePath,
   stripDriveLetter,
-  toUNCPosix,
   toUnixFormat,
-} from "../src/platform";
+  UNCPathNotSupportedError,
+} from "../src";
 
 describe("getWindowsDriveLetter", () => {
   it("should return the uppercase drive letter for valid Windows paths", () => {
@@ -117,10 +117,14 @@ describe("stripDriveLetter", () => {
   it("should return the original string for paths without drive letters", () => {
     expect.soft(stripDriveLetter("/unix/path")).toBe("/unix/path");
     expect.soft(stripDriveLetter("relative/path")).toBe("relative/path");
-    expect.soft(stripDriveLetter("\\\\server\\share")).toBe("\\\\server\\share");
     expect.soft(stripDriveLetter("file.txt")).toBe("file.txt");
     expect.soft(stripDriveLetter("./current/dir")).toBe("./current/dir");
     expect.soft(stripDriveLetter("../parent/dir")).toBe("../parent/dir");
+  });
+
+  it("should throw UNCPathNotSupportedError for UNC paths", () => {
+    expect.soft(() => stripDriveLetter("\\\\server\\share")).toThrow(UNCPathNotSupportedError);
+    expect.soft(() => stripDriveLetter("//server/share")).toThrow(UNCPathNotSupportedError);
   });
 
   it("should not strip drive-like patterns without separators", () => {
@@ -221,14 +225,12 @@ describe("toUnixFormat", () => {
     expect.soft(toUnixFormat("C:\\Windows\\System32")).toBe("/Windows/System32");
     expect.soft(toUnixFormat("D:\\path\\to\\file.txt")).toBe("/path/to/file.txt");
     expect.soft(toUnixFormat("\\server\\share\\file")).toBe("/server/share/file");
-    expect.soft(toUnixFormat("\\\\server\\\\share\\\\file")).toBe("//server/share/file");
   });
 
   it("should handle mixed separators in Windows paths", () => {
     expect.soft(toUnixFormat("C:\\Windows/System32\\file.txt")).toBe("/Windows/System32/file.txt");
     expect.soft(toUnixFormat("D:/path\\to\\file")).toBe("/path/to/file");
     expect.soft(toUnixFormat("\\server/share\\file")).toBe("/server/share/file");
-    expect.soft(toUnixFormat("\\\\server\\share//file")).toBe("//server/share/file");
   });
 
   it("should strip Windows drive letters", () => {
@@ -249,10 +251,10 @@ describe("toUnixFormat", () => {
     expect.soft(toUnixFormat("./current/dir")).toBe("/current/dir");
   });
 
-  it("should handle UNC paths", () => {
-    expect.soft(toUnixFormat("\\\\server\\share")).toBe("//server/share");
-    expect.soft(toUnixFormat("\\\\server\\share\\path")).toBe("//server/share/path");
-    expect.soft(toUnixFormat("//server/share/path")).toBe("//server/share/path");
+  it("should throw UNCPathNotSupportedError for UNC paths", () => {
+    expect.soft(() => toUnixFormat("\\\\server\\share")).toThrow(UNCPathNotSupportedError);
+    expect.soft(() => toUnixFormat("\\\\server\\share\\path")).toThrow(UNCPathNotSupportedError);
+    expect.soft(() => toUnixFormat("//server/share/path")).toThrow(UNCPathNotSupportedError);
   });
 
   it("should handle empty strings and whitespace", () => {
@@ -269,7 +271,6 @@ describe("toUnixFormat", () => {
 
   it("should handle paths with multiple consecutive separators", () => {
     expect.soft(toUnixFormat("C:\\\\path\\\\to\\\\file")).toBe("/path/to/file");
-    expect.soft(toUnixFormat("//server//share//file")).toBe("//server/share/file");
     expect.soft(toUnixFormat("path//to//file")).toBe("/path/to/file");
   });
 
@@ -285,7 +286,6 @@ describe("toUnixFormat", () => {
 
   it("should handle trailing separators", () => {
     expect.soft(toUnixFormat("C:\\folder\\")).toBe("/folder");
-    expect.soft(toUnixFormat("\\\\server\\share\\")).toBe("//server/share");
     expect.soft(toUnixFormat("relative/path/")).toBe("/relative/path");
   });
 
@@ -307,228 +307,20 @@ describe("toUnixFormat", () => {
     expect.soft(toUnixFormat(".\\current\\file")).toBe("/current/file");
   });
 
-  it("should handle UNC edge cases", () => {
-    expect.soft(toUnixFormat("\\\\192.168.1.100\\share\\file")).toBe("//192.168.1.100/share/file");
-    expect.soft(toUnixFormat("\\\\server\\c$\\windows")).toBe("//server/c$/windows");
-    expect.soft(toUnixFormat("\\\\server-name.domain.com\\share")).toBe("//server-name.domain.com/share");
-  });
 });
 
-describe("getAnyUNCRoot", () => {
-  it("should extract root from Windows UNC paths", () => {
-    expect.soft(getAnyUNCRoot("\\\\server\\share")).toBe("//server/share");
-    expect.soft(getAnyUNCRoot("\\\\server\\share\\")).toBe("//server/share");
-    expect.soft(getAnyUNCRoot("\\\\server\\share\\path")).toBe("//server/share");
-    expect.soft(getAnyUNCRoot("\\\\server\\share\\deep\\nested\\path")).toBe("//server/share");
-    expect.soft(getAnyUNCRoot("\\\\fileserver\\documents\\folder\\file.txt")).toBe("//fileserver/documents");
+describe("assertNotUNCPath", () => {
+  it("should not throw for non-UNC paths", () => {
+    expect(() => assertNotUNCPath("C:\\Windows\\System32")).not.toThrow();
+    expect(() => assertNotUNCPath("D:\\path\\to\\file")).not.toThrow();
+    expect(() => assertNotUNCPath("/usr/local/bin")).not.toThrow();
+    expect(() => assertNotUNCPath("relative/path")).not.toThrow();
+    expect(() => assertNotUNCPath("file.txt")).not.toThrow();
   });
 
-  it("should extract root from Unix UNC paths", () => {
-    expect.soft(getAnyUNCRoot("//server/share")).toBe("//server/share");
-    expect.soft(getAnyUNCRoot("//server/share/")).toBe("//server/share");
-    expect.soft(getAnyUNCRoot("//server/share/path")).toBe("//server/share");
-    expect.soft(getAnyUNCRoot("//server/share/deep/nested/path")).toBe("//server/share");
-    expect.soft(getAnyUNCRoot("//fileserver/documents/folder/file.txt")).toBe("//fileserver/documents");
-  });
-
-  it("should handle mixed separators", () => {
-    expect.soft(getAnyUNCRoot("\\\\server\\share/path")).toBe("//server/share");
-    expect.soft(getAnyUNCRoot("\\\\server/share\\path")).toBe("//server/share");
-    expect.soft(getAnyUNCRoot("//server\\share/path")).toBe("//server/share");
-    expect.soft(getAnyUNCRoot("//server/share\\path")).toBe("//server/share");
-  });
-
-  it("should handle IP addresses as server names", () => {
-    expect.soft(getAnyUNCRoot("\\\\192.168.1.100\\backup")).toBe("//192.168.1.100/backup");
-    expect.soft(getAnyUNCRoot("//10.0.0.5/shared")).toBe("//10.0.0.5/shared");
-    expect.soft(getAnyUNCRoot("\\\\127.0.0.1\\temp\\file.txt")).toBe("//127.0.0.1/temp");
-  });
-
-  it("should handle domain names and special characters", () => {
-    expect.soft(getAnyUNCRoot("\\\\server.domain.com\\share")).toBe("//server.domain.com/share");
-    expect.soft(getAnyUNCRoot("//file-server.company.org/public")).toBe("//file-server.company.org/public");
-    expect.soft(getAnyUNCRoot("\\\\server_01\\share_name")).toBe("//server_01/share_name");
-    expect.soft(getAnyUNCRoot("//server-2022/backup$")).toBe("//server-2022/backup$");
-  });
-
-  it("should return null for invalid inputs", () => {
-    expect.soft(getAnyUNCRoot(null as any)).toBe(null);
-    expect.soft(getAnyUNCRoot(undefined as any)).toBe(null);
-    expect.soft(getAnyUNCRoot("")).toBe(null);
-    expect.soft(getAnyUNCRoot("   ")).toBe(null);
-  });
-
-  it("should return null for strings that are too short", () => {
-    expect.soft(getAnyUNCRoot("//")).toBe(null);
-    expect.soft(getAnyUNCRoot("\\\\")).toBe(null);
-    expect.soft(getAnyUNCRoot("//a")).toBe(null);
-    expect.soft(getAnyUNCRoot("\\\\a")).toBe(null);
-    expect.soft(getAnyUNCRoot("//a/")).toBe(null);
-  });
-
-  it("should return null for non-UNC paths", () => {
-    expect.soft(getAnyUNCRoot("C:\\Windows\\System32")).toBe(null);
-    expect.soft(getAnyUNCRoot("/usr/local/bin")).toBe(null);
-    expect.soft(getAnyUNCRoot("relative/path")).toBe(null);
-    expect.soft(getAnyUNCRoot("\\single\\backslash")).toBe(null);
-    expect.soft(getAnyUNCRoot("/single/slash")).toBe(null);
-    expect.soft(getAnyUNCRoot("file.txt")).toBe(null);
-  });
-
-  it("should return null for incomplete UNC paths", () => {
-    expect.soft(getAnyUNCRoot("\\\\server")).toBe(null);
-    expect.soft(getAnyUNCRoot("//server")).toBe(null);
-    expect.soft(getAnyUNCRoot("\\\\server\\")).toBe(null);
-    expect.soft(getAnyUNCRoot("//server/")).toBe(null);
-    expect.soft(getAnyUNCRoot("\\\\\\share")).toBe(null);
-    expect.soft(getAnyUNCRoot("///share")).toBe(null);
-  });
-
-  it("should handle minimum valid UNC paths", () => {
-    expect.soft(getAnyUNCRoot("\\\\a\\b")).toBe("//a/b");
-    expect.soft(getAnyUNCRoot("//a/b")).toBe("//a/b");
-    expect.soft(getAnyUNCRoot("\\\\x\\y\\")).toBe("//x/y");
-    expect.soft(getAnyUNCRoot("//x/y/")).toBe("//x/y");
-  });
-
-  it("should handle special characters in server and share names", () => {
-    expect.soft(getAnyUNCRoot("\\\\server-01\\my_share")).toBe("//server-01/my_share");
-    expect.soft(getAnyUNCRoot("//server.local/share$")).toBe("//server.local/share$");
-    expect.soft(getAnyUNCRoot("\\\\file_server\\backup-2024")).toBe("//file_server/backup-2024");
-  });
-
-  it("should handle very long paths", () => {
-    const longPath = "\\\\very-long-server-name.domain.company.com\\extremely-long-share-name\\very\\deep\\nested\\folder\\structure\\with\\many\\levels\\file.txt";
-    expect(
-      getAnyUNCRoot(longPath),
-    ).toBe("//very-long-server-name.domain.company.com/extremely-long-share-name");
-  });
-
-  it("should return null for malformed UNC-like paths", () => {
-    expect.soft(getAnyUNCRoot("\\\\server\\\\share")).toBe(null);
-    expect.soft(getAnyUNCRoot("//server//share")).toBe(null);
-    expect.soft(getAnyUNCRoot("\\\\server/\\share")).toBe(null);
-    expect.soft(getAnyUNCRoot("\\\\\\server\\share")).toBe(null);
-    expect.soft(getAnyUNCRoot("///server/share")).toBe(null);
-  });
-
-  it("should preserve case in server and share names", () => {
-    expect.soft(getAnyUNCRoot("\\\\SERVER\\Share")).toBe("//SERVER/Share");
-    expect.soft(getAnyUNCRoot("//FileServer/PublicShare")).toBe("//FileServer/PublicShare");
-  });
-
-  it("should handle paths with special suffixes", () => {
-    expect.soft(getAnyUNCRoot("\\\\server\\share?param=value")).toBe("//server/share?param=value");
-    expect.soft(getAnyUNCRoot("//server/share#anchor")).toBe("//server/share#anchor");
-    expect.soft(getAnyUNCRoot("\\\\server\\share@version")).toBe("//server/share@version");
-  });
-});
-
-describe("toUNCPosix", () => {
-  it("should convert Windows UNC paths to POSIX format", () => {
-    expect.soft(toUNCPosix("\\\\server\\share")).toBe("//server/share");
-    expect.soft(toUNCPosix("\\\\server\\share\\")).toBe("//server/share");
-    expect.soft(toUNCPosix("\\\\server\\share\\file")).toBe("//server/share/file");
-    expect.soft(toUNCPosix("\\\\server\\share\\deep\\nested\\path")).toBe("//server/share/deep/nested/path");
-    expect.soft(toUNCPosix("\\\\fileserver\\documents\\folder\\file.txt")).toBe("//fileserver/documents/folder/file.txt");
-  });
-
-  it("should pass through valid POSIX UNC paths", () => {
-    expect.soft(toUNCPosix("//server/share")).toBe("//server/share");
-    expect.soft(toUNCPosix("//server/share/")).toBe("//server/share");
-    expect.soft(toUNCPosix("//server/share/file")).toBe("//server/share/file");
-    expect.soft(toUNCPosix("//server/share/deep/nested/path")).toBe("//server/share/deep/nested/path");
-    expect.soft(toUNCPosix("//fileserver/documents/folder/file.txt")).toBe("//fileserver/documents/folder/file.txt");
-  });
-
-  it("should handle mixed separators", () => {
-    expect.soft(toUNCPosix("\\\\server\\share/path")).toBe("//server/share/path");
-    expect.soft(toUNCPosix("\\\\server/share\\path")).toBe("//server/share/path");
-    expect.soft(toUNCPosix("//server\\share/path")).toBe("//server/share/path");
-    expect.soft(toUNCPosix("//server/share\\path")).toBe("//server/share/path");
-  });
-
-  it("should normalize malformed UNC paths", () => {
-    expect.soft(toUNCPosix("\\\\\\server\\share")).toBe("//server/share");
-    expect.soft(toUNCPosix("\\\\server\\\\share")).toBe("//server/share");
-    expect.soft(toUNCPosix("///server/share")).toBe("//server/share");
-    expect.soft(toUNCPosix("//server//share")).toBe("//server/share");
-    expect.soft(toUNCPosix("\\\\server\\\\\\share\\\\file")).toBe("//server/share/file");
-  });
-
-  it("should handle IP addresses and special server names", () => {
-    expect.soft(toUNCPosix("\\\\192.168.1.100\\backup")).toBe("//192.168.1.100/backup");
-    expect.soft(toUNCPosix("//10.0.0.5/shared")).toBe("//10.0.0.5/shared");
-    expect.soft(toUNCPosix("\\\\server.domain.com\\share")).toBe("//server.domain.com/share");
-    expect.soft(toUNCPosix("\\\\file-server\\my_share")).toBe("//file-server/my_share");
-    expect.soft(toUNCPosix("\\\\server01\\share$")).toBe("//server01/share$");
-  });
-
-  it("should return null for invalid inputs", () => {
-    expect.soft(() => toUNCPosix(null as any)).toThrow(TypeError);
-    expect.soft(() => toUNCPosix(undefined as any)).toThrow(TypeError);
-    expect.soft(toUNCPosix("")).toBe(null);
-    expect.soft(toUNCPosix("   ")).toBe(null);
-  });
-
-  it("should return null for non-UNC paths", () => {
-    expect.soft(toUNCPosix("C:\\Windows\\System32")).toBe(null);
-    expect.soft(toUNCPosix("D:\\path\\to\\file")).toBe(null);
-    expect.soft(toUNCPosix("/usr/local/bin")).toBe(null);
-    expect.soft(toUNCPosix("relative/path")).toBe(null);
-    expect.soft(toUNCPosix("\\single\\backslash")).toBe(null);
-    expect.soft(toUNCPosix("/single/slash")).toBe(null);
-    expect.soft(toUNCPosix("file.txt")).toBe(null);
-  });
-
-  it("should return null for incomplete UNC paths", () => {
-    expect.soft(toUNCPosix("\\\\")).toBe(null);
-    expect.soft(toUNCPosix("//")).toBe(null);
-    expect.soft(toUNCPosix("\\\\server")).toBe(null);
-    expect.soft(toUNCPosix("//server")).toBe(null);
-    expect.soft(toUNCPosix("\\\\server\\")).toBe(null);
-    expect.soft(toUNCPosix("//server/")).toBe(null);
-    expect.soft(toUNCPosix("\\\\\\share")).toBe(null);
-    expect.soft(toUNCPosix("///share")).toBe(null);
-  });
-
-  it("should handle minimum valid UNC paths", () => {
-    expect.soft(toUNCPosix("\\\\a\\b")).toBe("//a/b");
-    expect.soft(toUNCPosix("//a/b")).toBe("//a/b");
-    expect.soft(toUNCPosix("\\\\x\\y\\")).toBe("//x/y");
-    expect.soft(toUNCPosix("//x/y/")).toBe("//x/y");
-  });
-
-  it("should handle whitespace correctly", () => {
-    expect.soft(toUNCPosix("  \\\\server\\share  ")).toBe("//server/share");
-    expect.soft(toUNCPosix("  //server/share  ")).toBe("//server/share");
-    expect.soft(toUNCPosix("\\\\server name\\share name")).toBe("//server name/share name");
-  });
-
-  it("should preserve special characters", () => {
-    expect.soft(toUNCPosix("\\\\server\\share with spaces")).toBe("//server/share with spaces");
-    expect.soft(toUNCPosix("\\\\server\\share-with-dashes")).toBe("//server/share-with-dashes");
-    expect.soft(toUNCPosix("\\\\server\\share_with_underscores")).toBe("//server/share_with_underscores");
-    expect.soft(toUNCPosix("\\\\server\\share$")).toBe("//server/share$");
-    expect.soft(toUNCPosix("\\\\server\\c$\\windows")).toBe("//server/c$/windows");
-  });
-
-  it("should handle very long paths", () => {
-    const longPath = "\\\\very-long-server-name.domain.company.com\\extremely-long-share-name\\very\\deep\\nested\\folder\\structure\\with\\many\\levels\\and\\a\\very\\long\\filename.txt";
-    const expected = "//very-long-server-name.domain.company.com/extremely-long-share-name/very/deep/nested/folder/structure/with/many/levels/and/a/very/long/filename.txt";
-    expect(toUNCPosix(longPath)).toBe(expected);
-  });
-
-  it("should preserve case in server and share names", () => {
-    expect.soft(toUNCPosix("\\\\SERVER\\Share")).toBe("//SERVER/Share");
-    expect.soft(toUNCPosix("\\\\FileServer\\PublicShare")).toBe("//FileServer/PublicShare");
-    expect.soft(toUNCPosix("//MixedCase/ShareName")).toBe("//MixedCase/ShareName");
-  });
-
-  it("should handle trailing separators consistently", () => {
-    expect.soft(toUNCPosix("\\\\server\\share\\")).toBe("//server/share");
-    expect.soft(toUNCPosix("\\\\server\\share\\\\")).toBe("//server/share");
-    expect.soft(toUNCPosix("//server/share/")).toBe("//server/share");
-    expect.soft(toUNCPosix("//server/share//")).toBe("//server/share");
+  it("should throw UNCPathNotSupportedError for UNC paths", () => {
+    expect(() => assertNotUNCPath("\\\\server\\share")).toThrow(UNCPathNotSupportedError);
+    expect(() => assertNotUNCPath("//server/share")).toThrow(UNCPathNotSupportedError);
+    expect(() => assertNotUNCPath("\\\\192.168.1.100\\backup")).toThrow(UNCPathNotSupportedError);
   });
 });

--- a/packages/path-utils/test/platform.test.ts
+++ b/packages/path-utils/test/platform.test.ts
@@ -306,7 +306,6 @@ describe("toUnixFormat", () => {
     expect.soft(toUnixFormat("..\\parent\\file")).toBe("/parent/file");
     expect.soft(toUnixFormat(".\\current\\file")).toBe("/current/file");
   });
-
 });
 
 describe("assertNotUNCPath", () => {

--- a/packages/path-utils/test/security.windows.test.ts
+++ b/packages/path-utils/test/security.windows.test.ts
@@ -327,8 +327,6 @@ describe.runIf(isWindows)("utils - windows", () => {
       });
     });
 
-
-
     describe("unsupported scenarios", () => {
       it("should throw WindowsPathBehaviorNotImplementedError for unsupported combinations", () => {
         // Test with a scenario that doesn't match any of the implemented cases


### PR DESCRIPTION
### 🔗 Linked issue

resolves #239 

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This PR removes unc support from the path logic which is implemented in #238, the reason i am doing this is there is not much need for unc support. And the logic gets very complicated when we need to support it.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to UCDJS!
----------------------------------------------------------------------->
