### PR TITLE
refactor(test-utils): rename setupMockStore to mockStoreApi

### DIFF
--- a/.changeset/brave-moths-sneeze.md
+++ b/.changeset/brave-moths-sneeze.md
@@ -1,0 +1,20 @@
+---
+"@ucdjs/test-utils": minor
+---
+
+Rename `setupMockStore` to `mockStoreApi` for better clarity
+
+The function has been renamed from `setupMockStore` to `mockStoreApi` to better reflect that it sets up MSW HTTP route handlers for the UCD API, rather than creating a mock store object.
+
+**Migration:**
+```typescript
+// Before
+import { setupMockStore } from '@ucdjs/test-utils';
+setupMockStore();
+
+// After
+import { mockStoreApi } from '@ucdjs/test-utils';
+mockStoreApi();
+```
+
+The old `setupMockStore` name is still exported as a deprecated alias for backward compatibility.

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -1,3 +1,3 @@
 export { isLinux, isMac, isUnix, isWindows } from "./conditions";
-export { setupMockStore } from "./mock-store";
+export { mockStoreApi as setupMockStore } from "./mock-store";
 export type { MockStoreConfig, StoreEndpointConfig, StoreEndpoints } from "./mock-store";

--- a/packages/test-utils/src/mock-store/index.ts
+++ b/packages/test-utils/src/mock-store/index.ts
@@ -16,7 +16,7 @@ const DEFAULT_RESPONSES = {
   "/api/v1/files/:wildcard": true,
 } as const satisfies StoreResponseOverrides;
 
-export function setupMockStore(config?: MockStoreConfig): void {
+export function mockStoreApi(config?: MockStoreConfig): void {
   const {
     baseUrl = "https://api.ucdjs.dev",
     responses,

--- a/packages/ucd-store/test/core/init.test.ts
+++ b/packages/ucd-store/test/core/init.test.ts
@@ -3,7 +3,7 @@ import type { UCDStoreManifest } from "@ucdjs/schemas";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
-import { setupMockStore } from "#internal/test-utils/mock-store";
+import { mockStoreApi } from "#internal/test-utils/mock-store";
 import { HttpResponse, mockFetch } from "#internal/test-utils/msw";
 import { UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
 import { UCDJS_API_BASE_URL } from "@ucdjs/env";
@@ -21,7 +21,7 @@ const DEFAULT_VERSIONS = {
 
 describe("store init", () => {
   beforeEach(() => {
-    setupMockStore({
+    mockStoreApi({
       responses: {
         "/api/v1/versions": [...UNICODE_VERSION_METADATA],
         "/api/v1/versions/:version/file-tree": [{

--- a/packages/ucd-store/test/file-operations/capability-requirements.test.ts
+++ b/packages/ucd-store/test/file-operations/capability-requirements.test.ts
@@ -1,4 +1,4 @@
-import { setupMockStore } from "#internal/test-utils/mock-store";
+import { mockStoreApi } from "#internal/test-utils/mock-store";
 import { UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
 import { UCDJS_API_BASE_URL } from "@ucdjs/env";
 import { BridgeUnsupportedOperation, defineFileSystemBridge } from "@ucdjs/fs-bridge";
@@ -7,7 +7,7 @@ import { UCDStore } from "../../src/store";
 
 describe("capability requirements", () => {
   beforeEach(() => {
-    setupMockStore({
+    mockStoreApi({
       baseUrl: UCDJS_API_BASE_URL,
       responses: {
         "/api/v1/versions": [...UNICODE_VERSION_METADATA],

--- a/packages/ucd-store/test/file-operations/file-paths.test.ts
+++ b/packages/ucd-store/test/file-operations/file-paths.test.ts
@@ -1,4 +1,4 @@
-import { setupMockStore } from "#internal/test-utils/mock-store";
+import { mockStoreApi } from "#internal/test-utils/mock-store";
 import { UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
 import { UCDJS_API_BASE_URL } from "@ucdjs/env";
 import { assert, beforeEach, describe, expect, it, vi } from "vitest";
@@ -7,7 +7,7 @@ import { createNodeUCDStore } from "../../src/factory";
 
 describe("file paths", () => {
   beforeEach(() => {
-    setupMockStore({
+    mockStoreApi({
       baseUrl: UCDJS_API_BASE_URL,
       responses: {
         "/api/v1/versions": [...UNICODE_VERSION_METADATA],

--- a/packages/ucd-store/test/file-operations/file-tree.test.ts
+++ b/packages/ucd-store/test/file-operations/file-tree.test.ts
@@ -1,4 +1,4 @@
-import { setupMockStore } from "#internal/test-utils/mock-store";
+import { mockStoreApi } from "#internal/test-utils/mock-store";
 import { UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
 import { UCDJS_API_BASE_URL } from "@ucdjs/env";
 import { flattenFilePaths } from "@ucdjs/shared";
@@ -8,7 +8,7 @@ import { createNodeUCDStore } from "../../src/factory";
 
 describe("file tree", () => {
   beforeEach(() => {
-    setupMockStore({
+    mockStoreApi({
       baseUrl: UCDJS_API_BASE_URL,
       responses: {
         "/api/v1/versions": [...UNICODE_VERSION_METADATA],

--- a/packages/ucd-store/test/file-operations/get-file.test.ts
+++ b/packages/ucd-store/test/file-operations/get-file.test.ts
@@ -1,4 +1,4 @@
-import { setupMockStore } from "#internal/test-utils/mock-store";
+import { mockStoreApi } from "#internal/test-utils/mock-store";
 import { UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
 import { UCDJS_API_BASE_URL } from "@ucdjs/env";
 import { PathTraversalError } from "@ucdjs/path-utils";
@@ -9,7 +9,7 @@ import { createNodeUCDStore } from "../../src/factory";
 
 describe("get file", () => {
   beforeEach(() => {
-    setupMockStore({
+    mockStoreApi({
       baseUrl: UCDJS_API_BASE_URL,
       responses: {
         "/api/v1/versions": [...UNICODE_VERSION_METADATA],

--- a/packages/ucd-store/test/maintenance/analyze.test.ts
+++ b/packages/ucd-store/test/maintenance/analyze.test.ts
@@ -1,5 +1,5 @@
 import type { UnicodeTree } from "@ucdjs/schemas";
-import { setupMockStore } from "#internal/test-utils/mock-store";
+import { mockStoreApi } from "#internal/test-utils/mock-store";
 import { HttpResponse, mockFetch } from "#internal/test-utils/msw";
 import { UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
 import { UCDJS_API_BASE_URL } from "@ucdjs/env";
@@ -41,7 +41,7 @@ const MOCK_FILES = [
 
 describe("analyze operations", () => {
   beforeEach(() => {
-    setupMockStore({
+    mockStoreApi({
       baseUrl: UCDJS_API_BASE_URL,
       responses: {
         "/api/v1/versions": [...UNICODE_VERSION_METADATA],

--- a/packages/ucd-store/test/maintenance/clean.test.ts
+++ b/packages/ucd-store/test/maintenance/clean.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { setupMockStore } from "#internal/test-utils/mock-store";
+import { mockStoreApi } from "#internal/test-utils/mock-store";
 import { HttpResponse, mockFetch } from "#internal/test-utils/msw";
 import { UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
 import { dedent } from "@luxass/utils";
@@ -11,7 +11,7 @@ import { captureSnapshot, testdir } from "vitest-testdirs";
 
 describe("store clean", () => {
   beforeEach(() => {
-    setupMockStore({
+    mockStoreApi({
       baseUrl: UCDJS_API_BASE_URL,
       responses: {
         "/api/v1/versions": [...UNICODE_VERSION_METADATA],

--- a/packages/ucd-store/test/maintenance/mirror.test.ts
+++ b/packages/ucd-store/test/maintenance/mirror.test.ts
@@ -1,6 +1,6 @@
 import type { ApiError } from "@ucdjs/schemas";
 import { existsSync } from "node:fs";
-import { setupMockStore } from "#internal/test-utils/mock-store";
+import { mockStoreApi } from "#internal/test-utils/mock-store";
 import { HttpResponse, mockFetch } from "#internal/test-utils/msw";
 import { UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
 import { UCDJS_API_BASE_URL } from "@ucdjs/env";
@@ -11,7 +11,7 @@ import { testdir } from "vitest-testdirs";
 
 describe("store mirror", () => {
   beforeEach(() => {
-    setupMockStore({
+    mockStoreApi({
       baseUrl: UCDJS_API_BASE_URL,
       responses: {
         "/api/v1/versions": [...UNICODE_VERSION_METADATA],

--- a/packages/ucd-store/test/maintenance/repair.test.ts
+++ b/packages/ucd-store/test/maintenance/repair.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs";
-import { setupMockStore } from "#internal/test-utils/mock-store";
+import { mockStoreApi } from "#internal/test-utils/mock-store";
 import { HttpResponse } from "#internal/test-utils/msw";
 import { UNICODE_VERSION_METADATA } from "@luxass/unicode-utils-new";
 import { UCDJS_API_BASE_URL } from "@ucdjs/env";
@@ -9,7 +9,7 @@ import { testdir } from "vitest-testdirs";
 
 describe("store repair", () => {
   beforeEach(() => {
-    setupMockStore({
+    mockStoreApi({
       baseUrl: UCDJS_API_BASE_URL,
       responses: {
         "/api/v1/versions": [...UNICODE_VERSION_METADATA],


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to UCDJS!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced mockStoreApi in @ucdjs/test-utils for configuring MSW HTTP route handlers.
- Chores
  - setupMockStore remains available as a deprecated alias for backward compatibility.
- Tests
  - Updated test suites to use mockStoreApi instead of setupMockStore without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->