### PR TITLE
fix(fs-bridge): infer no options schema as never

### DIFF
--- a/.changeset/floppy-news-smile.md
+++ b/.changeset/floppy-news-smile.md
@@ -1,0 +1,5 @@
+---
+"@ucdjs/fs-bridge": patch
+---
+
+infer bridge option schema as never, if not provided

--- a/packages/fs-bridge/src/define.ts
+++ b/packages/fs-bridge/src/define.ts
@@ -18,7 +18,7 @@ import {
 const debug = createDebugger("ucdjs:fs-bridge:define");
 
 export function defineFileSystemBridge<
-  TOptionsSchema extends z.ZodType,
+  TOptionsSchema extends z.ZodType = z.ZodNever,
   TState extends Record<string, unknown> = Record<string, unknown>,
 >(
   fsBridge: FileSystemBridgeObject<TOptionsSchema, TState>,

--- a/packages/fs-bridge/test/types.test-d.ts
+++ b/packages/fs-bridge/test/types.test-d.ts
@@ -1,0 +1,60 @@
+import type { FileSystemBridgeFactory } from "../src/types";
+import { defineFileSystemBridge } from "@ucdjs/fs-bridge";
+import { describe, expectTypeOf, it } from "vitest";
+import z from "zod";
+
+describe("defineFileSystemBridge", () => {
+  it("should infer the correct types for options and state", () => {
+    const MyBridge = defineFileSystemBridge({
+      optionsSchema: z.object({
+        basePath: z.string(),
+        recursive: z.boolean().optional(),
+      }),
+      state: {
+        initialized: false,
+      },
+      setup({ options, state }) {
+        expectTypeOf(options).toEqualTypeOf<{
+          basePath: string;
+          recursive?: boolean | undefined;
+        }>();
+        expectTypeOf(state).toEqualTypeOf<{
+          initialized: boolean;
+        }>();
+
+        return {};
+      },
+    });
+
+    expectTypeOf(MyBridge).toExtend<FileSystemBridgeFactory<z.ZodObject<{
+      basePath: z.ZodString;
+      recursive: z.ZodOptional<z.ZodBoolean>;
+    }, z.core.$strip>>>();
+  });
+
+  it("should work with no optionsSchema and no state", () => {
+    const SimpleBridge = defineFileSystemBridge({
+      setup() {
+        return {};
+      },
+    });
+
+    expectTypeOf(SimpleBridge).toExtend<FileSystemBridgeFactory<z.ZodNever>>();
+  });
+
+  it("should work with no optionsSchema but with state", () => {
+    const StateBridge = defineFileSystemBridge({
+      state: {
+        count: 0,
+      },
+      setup({ state }) {
+        expectTypeOf(state).toEqualTypeOf<{
+          count: number;
+        }>();
+        return {};
+      },
+    });
+
+    expectTypeOf(StateBridge).toExtend<FileSystemBridgeFactory<z.ZodNever>>();
+  });
+});


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to UCDJS!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Defining a file system bridge no longer requires an options schema; if omitted, options are treated as not applicable. Improves API ergonomics without changing runtime behavior.
* **Tests**
  * Added comprehensive type inference and validation tests for scenarios with and without an options schema, including custom state cases.
* **Chores**
  * Added a changeset to publish a patch update for the fs-bridge package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->