### PR TITLE
chore: update OpenAPI generation paths and configurations

### DIFF
--- a/.github/workflows/openapi-artifact.yml
+++ b/.github/workflows/openapi-artifact.yml
@@ -62,10 +62,8 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: openapi-${{ matrix.artifact }}
-          path: ./apps/api/.generated/openapi.json
+          path: ./ucd-generated/api/openapi.json
           if-no-files-found: error
-          # TODO: maybe we should move the openapi.json to a non hidden location?
-          include-hidden-files: true
 
   report-changes:
     name: report openapi schema changes

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ dist
 tsconfig.test.vitest-temp.json
 data
 **/.ucd-files
+ucd-generated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,7 @@ The API worker (apps/api) has multiple deployment environments configured in `wr
 
 2. **OpenAPI spec regeneration**
    - After changing API routes or Zod schemas, always run `cd apps/api && pnpm build:openapi`
-   - This regenerates `.generated/openapi.json` which is used by `@ucdjs/fetch`
+   - This regenerates `<repository-root>/ucd-generated/api/openapi.json` which is used by `@ucdjs/fetch`
    - It's a build dependency in turbo.json, so full builds will regenerate it
 
 3. **Using #internal/test-utils in tests**

--- a/apps/api/.gitignore
+++ b/apps/api/.gitignore
@@ -2,4 +2,3 @@ node_modules
 .wrangler
 dist
 .dev.vars
-.generated

--- a/apps/api/.spectral.yml
+++ b/apps/api/.spectral.yml
@@ -3,13 +3,13 @@ extends:
 
 overrides:
   - files:
-      - .generated/openapi.json#/paths/~1api~1v1~1files~1.ucd-store.json
+      - ../../ucd-generated/api/openapi.json#/paths/~1api~1v1~1files~1.ucd-store.json
     rules:
       luxass/no-file-extensions-in-paths: off
       luxass/paths-kebab-case: off
 
   - files:
-      - .generated/openapi.json#/paths/~1.well-known~1ucd-config.json
+      - ../../ucd-generated/api/openapi.json#/paths/~1.well-known~1ucd-config.json
     rules:
       luxass/no-file-extensions-in-paths: off
       luxass/paths-kebab-case: off

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,10 +12,10 @@
     "test": "pnpm vitest --run",
     "test:watch": "pnpm vitest",
     "lint": "eslint .",
-    "lint:openapi": "spectral lint ./.generated/openapi.json",
+    "lint:openapi": "spectral lint ../../ucd-generated/api/openapi.json",
     "generate:types": "wrangler types ./wrangler-types.d.ts",
     "typecheck": "pnpm run generate:types && tsc --noEmit",
-    "clean": "git clean -xdf node_modules .wrangler dist .generated"
+    "clean": "git clean -xdf node_modules .wrangler dist ../../ucd-generated/api"
   },
   "dependencies": {
     "@hono/zod-openapi": "catalog:workers",

--- a/apps/api/scripts/build-openapi.ts
+++ b/apps/api/scripts/build-openapi.ts
@@ -5,7 +5,7 @@ import process from "node:process";
 import { buildOpenApiConfig } from "../src/openapi";
 import { getOpenAPI31Document } from "../src/worker";
 
-const root = path.resolve(import.meta.dirname, "../");
+const root = path.resolve(import.meta.dirname, "../../../");
 
 async function run() {
   const obj = getOpenAPI31Document(buildOpenApiConfig("x.y.z", [
@@ -15,11 +15,12 @@ async function run() {
     },
   ]));
 
-  if (!existsSync(path.join(root.toString(), "./.generated"))) {
-    await mkdir(path.join(root.toString(), "./.generated"), { recursive: true });
+  const outputPath = path.join(root, "ucd-generated/api");
+  if (!existsSync(outputPath)) {
+    await mkdir(outputPath, { recursive: true });
   }
 
-  await writeFile(path.join(root.toString(), "./.generated/openapi.json"), JSON.stringify(obj, null, 2));
+  await writeFile(path.join(outputPath, "openapi.json"), JSON.stringify(obj, null, 2));
 }
 
 run().catch((err) => {

--- a/apps/api/turbo.json
+++ b/apps/api/turbo.json
@@ -22,7 +22,7 @@
     "build:openapi": {
       "cache": false,
       "outputs": [
-        ".generated/openapi.json"
+        "../../ucd-generated/api/openapi.json"
       ]
     }
   }

--- a/packages/fetch/package.json
+++ b/packages/fetch/package.json
@@ -37,7 +37,7 @@
     "clean": "git clean -xdf dist node_modules",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
-    "generate:client": "npx openapi-typescript ../../apps/api/.generated/openapi.json -o ./src/.generated/api.d.ts",
+    "generate:client": "npx openapi-typescript ../../ucd-generated/api/openapi.json -o ./src/.generated/api.d.ts",
     "generate:client:local": "npx openapi-typescript http://localhost:8787/openapi.json -o ./src/.generated/api.d.ts"
   },
   "dependencies": {


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

* Changed output path for OpenAPI JSON to `../../ucd-generated/api/openapi.json`.
* Updated references in `.spectral.yml`, `package.json`, and `build-openapi.ts` to reflect new path.
* Modified `.gitignore` to exclude `ucd-generated` directory.
* Adjusted Turbo configuration to output OpenAPI JSON to the new location.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to UCDJS!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated OpenAPI regeneration guidance to use the new repository-level path.

- Chores
  - Relocated generated OpenAPI spec to a unified repository-level directory.
  - Updated CI to upload the artifact from the new location.
  - Adjusted lint/build/client-generation scripts to reference the new spec path.
  - Updated ignore rules to exclude the new generated directory and remove outdated ignores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->