### PR TITLE
fix: use full path in file-tree

### DIFF
--- a/apps/api/test/routes/v1_versions.test.ts
+++ b/apps/api/test/routes/v1_versions.test.ts
@@ -357,11 +357,11 @@ describe("v1_versions", () => {
   // eslint-disable-next-line test/prefer-lowercase-title
   describe("GET /api/v1/versions/{version}/file-tree", () => {
     const files: TraverseEntry[] = [
-      { type: "file", name: "file1.txt", path: "/Public/15.1.0/ucd/file1.txt" },
-      { type: "file", name: "file2.txt", path: "/Public/15.1.0/ucd/file2.txt" },
-      { type: "directory", name: "subdir", path: "/Public/15.1.0/ucd/subdir", children: [] },
-      { type: "file", name: "file3.txt", path: "/Public/15.1.0/ucd/subdir/file3.txt" },
-      { type: "file", name: "emoji-data.txt", path: "/Public/15.1.0/ucd/emoji/emoji-data.txt" },
+      { type: "file", name: "file1.txt", path: "Public/15.1.0/ucd/file1.txt" },
+      { type: "file", name: "file2.txt", path: "Public/15.1.0/ucd/file2.txt" },
+      { type: "directory", name: "subdir", path: "Public/15.1.0/ucd/subdir", children: [] },
+      { type: "file", name: "file3.txt", path: "Public/15.1.0/ucd/subdir/file3.txt" },
+      { type: "file", name: "emoji-data.txt", path: "Public/15.1.0/ucd/emoji/emoji-data.txt" },
     ];
 
     it("should return files for a valid Unicode version", async () => {

--- a/packages/fs-bridge/src/bridges/node.ts
+++ b/packages/fs-bridge/src/bridges/node.ts
@@ -9,6 +9,14 @@ import { defineFileSystemBridge } from "../define";
 
 const debug = createDebugger("ucdjs:fs-bridge:node");
 
+/**
+ * Normalizes path separators to forward slashes for cross-platform consistency.
+ * On Windows, converts backslashes to forward slashes.
+ */
+function normalizePathSeparators(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
 async function safeExists(path: string): Promise<boolean> {
   try {
     await fsp.stat(path);
@@ -79,7 +87,13 @@ const NodeFileSystemBridge = defineFileSystemBridge({
             ? nodePath.join(relativeToTarget, entry.name)
             : entry.name;
 
-          entryMap.set(entryRelativePath, fsEntry);
+          // Normalize path separators to forward slashes for cross-platform consistency
+          const normalizedPath = normalizePathSeparators(entryRelativePath);
+
+          // Update the path to be the full relative path
+          fsEntry.path = normalizedPath;
+
+          entryMap.set(normalizedPath, fsEntry);
 
           if (!relativeToTarget) {
             rootEntries.push(fsEntry);

--- a/packages/shared/src/filter.ts
+++ b/packages/shared/src/filter.ts
@@ -202,8 +202,8 @@ function internal__filterTreeStructure(
   const filteredEntries: TreeEntry[] = [];
 
   for (const entry of entries) {
-    // Construct the full path by combining parent path with entry path
-    const fullPath = parentPath ? `${parentPath}/${entry.path}` : entry.path;
+    // Since entry.path now contains the full path, use it directly
+    const fullPath = entry.path;
 
     if (entry.type === "file") {
       // For files, simply check if the full path matches the filter

--- a/packages/shared/src/flatten.ts
+++ b/packages/shared/src/flatten.ts
@@ -47,7 +47,7 @@ export function flattenFilePaths<T extends TreeNode>(entries: T[], prefix: strin
       : (file.path ?? file.name);
 
     if (file.type === "directory" && file.children) {
-      paths.push(...flattenFilePaths(file.children, fullPath));
+      paths.push(...flattenFilePaths(file.children, prefix));
     } else {
       paths.push(fullPath);
     }

--- a/packages/shared/test/filter.test.ts
+++ b/packages/shared/test/filter.test.ts
@@ -691,27 +691,27 @@ describe("filterTreeStructure", () => {
         {
           type: "file",
           name: "DerivedBidiClass.txt",
-          path: "DerivedBidiClass.txt",
+          path: "extracted/DerivedBidiClass.txt",
         },
         {
           type: "file",
           name: "config.json",
-          path: "config.json",
+          path: "extracted/config.json",
         },
         {
           type: "directory",
           name: "nested",
-          path: "nested",
+          path: "extracted/nested",
           children: [
             {
               type: "file",
               name: "DeepFile.txt",
-              path: "DeepFile.txt",
+              path: "extracted/nested/DeepFile.txt",
             },
             {
               type: "file",
               name: "debug.log",
-              path: "debug.log",
+              path: "extracted/nested/debug.log",
             },
           ],
         },
@@ -738,7 +738,7 @@ describe("filterTreeStructure", () => {
             {
               type: "file",
               name: "config.json",
-              path: "config.json",
+              path: "extracted/config.json",
             },
           ],
         },
@@ -772,17 +772,17 @@ describe("filterTreeStructure", () => {
             {
               type: "file",
               name: "DerivedBidiClass.txt",
-              path: "DerivedBidiClass.txt",
+              path: "extracted/DerivedBidiClass.txt",
             },
             {
               type: "directory",
               name: "nested",
-              path: "nested",
+              path: "extracted/nested",
               children: [
                 {
                   type: "file",
                   name: "DeepFile.txt",
-                  path: "DeepFile.txt",
+                  path: "extracted/nested/DeepFile.txt",
                 },
               ],
             },
@@ -806,12 +806,12 @@ describe("filterTreeStructure", () => {
             {
               type: "directory",
               name: "nested",
-              path: "nested",
+              path: "extracted/nested",
               children: [
                 {
                   type: "file",
                   name: "DeepFile.txt",
-                  path: "DeepFile.txt",
+                  path: "extracted/nested/DeepFile.txt",
                 },
               ],
             },
@@ -840,27 +840,27 @@ describe("filterTreeStructure", () => {
             {
               type: "file",
               name: "DerivedBidiClass.txt",
-              path: "DerivedBidiClass.txt",
+              path: "extracted/DerivedBidiClass.txt",
             },
             {
               type: "file",
               name: "config.json",
-              path: "config.json",
+              path: "extracted/config.json",
             },
             {
               type: "directory",
               name: "nested",
-              path: "nested",
+              path: "extracted/nested",
               children: [
                 {
                   type: "file",
                   name: "DeepFile.txt",
-                  path: "DeepFile.txt",
+                  path: "extracted/nested/DeepFile.txt",
                 },
                 {
                   type: "file",
                   name: "debug.log",
-                  path: "debug.log",
+                  path: "extracted/nested/debug.log",
                 },
               ],
             },
@@ -970,12 +970,12 @@ describe("filterTreeStructure", () => {
             {
               type: "directory",
               name: "nested",
-              path: "nested",
+              path: "extracted/nested",
               children: [
                 {
                   type: "file",
                   name: "DeepFile.txt",
-                  path: "DeepFile.txt",
+                  path: "extracted/nested/DeepFile.txt",
                 },
               ],
             },
@@ -1010,22 +1010,22 @@ describe("filterTreeStructure", () => {
             {
               type: "file",
               name: "DerivedBidiClass.txt",
-              path: "DerivedBidiClass.txt",
+              path: "extracted/DerivedBidiClass.txt",
             },
             {
               type: "file",
               name: "config.json",
-              path: "config.json",
+              path: "extracted/config.json",
             },
             {
               type: "directory",
               name: "nested",
-              path: "nested",
+              path: "extracted/nested",
               children: [
                 {
                   type: "file",
                   name: "DeepFile.txt",
-                  path: "DeepFile.txt",
+                  path: "extracted/nested/DeepFile.txt",
                 },
                 // debug.log should be excluded
               ],

--- a/packages/shared/test/flatten.test.ts
+++ b/packages/shared/test/flatten.test.ts
@@ -31,8 +31,8 @@ describe("flattenFilePaths", () => {
         path: "folder1",
         type: "directory",
         children: [
-          { type: "file", name: "file1.txt", path: "file1.txt" },
-          { type: "file", name: "file2.txt", path: "file2.txt" },
+          { type: "file", name: "file1.txt", path: "folder1/file1.txt" },
+          { type: "file", name: "file2.txt", path: "folder1/file2.txt" },
         ],
       },
     ]);
@@ -52,7 +52,7 @@ describe("flattenFilePaths", () => {
         name: "folder1",
         path: "folder1",
         children: [
-          { type: "file", name: "nested-file.txt", path: "nested-file.txt" },
+          { type: "file", name: "nested-file.txt", path: "folder1/nested-file.txt" },
         ],
       },
       { type: "file", name: "another-root-file.txt", path: "another-root-file.txt" },
@@ -75,17 +75,17 @@ describe("flattenFilePaths", () => {
           {
             type: "directory",
             name: "level2",
-            path: "level2",
+            path: "level1/level2",
             children: [
               {
                 type: "directory",
                 name: "level3",
-                path: "level3",
+                path: "level1/level2/level3",
                 children: [
                   {
                     type: "file",
                     name: "deep-file.txt",
-                    path: "deep-file.txt",
+                    path: "level1/level2/level3/deep-file.txt",
                   },
                 ],
               },
@@ -110,7 +110,7 @@ describe("flattenFilePaths", () => {
         name: "folder",
         path: "folder",
         children: [
-          { type: "file", name: "nested.txt", path: "nested.txt" },
+          { type: "file", name: "nested.txt", path: "folder/nested.txt" },
         ],
       },
     ], "prefix");
@@ -155,14 +155,14 @@ describe("flattenFilePaths", () => {
         name: "docs",
         path: "docs",
         children: [
-          { type: "file", name: "readme.md", path: "readme.md" },
+          { type: "file", name: "readme.md", path: "docs/readme.md" },
           {
             type: "directory",
             name: "api",
-            path: "api",
+            path: "docs/api",
             children: [
-              { type: "file", name: "index.html", path: "index.html" },
-              { type: "file", name: "methods.html", path: "methods.html" },
+              { type: "file", name: "index.html", path: "docs/api/index.html" },
+              { type: "file", name: "methods.html", path: "docs/api/methods.html" },
             ],
           },
         ],
@@ -172,13 +172,13 @@ describe("flattenFilePaths", () => {
         name: "src",
         path: "src",
         children: [
-          { type: "file", name: "index.ts", path: "index.ts" },
+          { type: "file", name: "index.ts", path: "src/index.ts" },
           {
             type: "directory",
             name: "utils",
             path: "utils",
             children: [
-              { type: "file", name: "helpers.ts", path: "helpers.ts" },
+              { type: "file", name: "helpers.ts", path: "src/utils/helpers.ts" },
             ],
           },
         ],

--- a/packages/test-utils/src/mock-store/handlers/file-tree.ts
+++ b/packages/test-utils/src/mock-store/handlers/file-tree.ts
@@ -41,7 +41,7 @@ export const fileTreeRoute = defineMockRouteHandler({
                 {
                   type: "file",
                   name: "DerivedBidiClass.txt",
-                  path: "DerivedBidiClass.txt",
+                  path: "extracted/DerivedBidiClass.txt",
                   lastModified: 1724609100000,
                 },
               ],

--- a/packages/ucd-store/test/file-operations/file-tree.test.ts
+++ b/packages/ucd-store/test/file-operations/file-tree.test.ts
@@ -63,19 +63,19 @@ describe("file tree", () => {
         children: [
           {
             name: "DerivedBidiClass.txt",
-            path: "DerivedBidiClass.txt",
+            path: "extracted/DerivedBidiClass.txt",
             type: "file",
           },
           {
             children: [
               {
                 name: "DeepFile.txt",
-                path: "DeepFile.txt",
+                path: "extracted/nested/DeepFile.txt",
                 type: "file",
               },
             ],
             name: "nested",
-            path: "nested",
+            path: "extracted/nested",
             type: "directory",
           },
         ],
@@ -231,7 +231,7 @@ describe("file tree", () => {
         children: [
           {
             name: "DerivedBidiClass.txt",
-            path: "DerivedBidiClass.txt",
+            path: "extracted/DerivedBidiClass.txt",
             type: "file",
           },
         ],
@@ -246,12 +246,12 @@ describe("file tree", () => {
         children: [
           {
             name: "DerivedBidiClass.txt",
-            path: "DerivedBidiClass.txt",
+            path: "extracted/DerivedBidiClass.txt",
             type: "file",
           },
           {
             name: "nested",
-            path: "nested",
+            path: "extracted/nested",
             type: "directory",
             children: [],
           },
@@ -291,17 +291,17 @@ describe("file tree", () => {
           children: [
             {
               name: "DerivedBidiClass.txt",
-              path: "DerivedBidiClass.txt",
+              path: "extracted/DerivedBidiClass.txt",
               type: "file",
             },
             {
               name: "nested",
-              path: "nested",
+              path: "extracted/nested",
               type: "directory",
               children: [
                 {
                   name: "DeepFile.txt",
-                  path: "DeepFile.txt",
+                  path: "extracted/nested/DeepFile.txt",
                   type: "file",
                 },
               ],
@@ -347,7 +347,7 @@ describe("file tree", () => {
           children: [
             {
               name: "DerivedBidiClass.txt",
-              path: "DerivedBidiClass.txt",
+              path: "extracted/DerivedBidiClass.txt",
               type: "file",
             },
           ],

--- a/packages/ucd-store/test/internal/files.test.ts
+++ b/packages/ucd-store/test/internal/files.test.ts
@@ -34,7 +34,7 @@ describe("getExpectedFilePaths", async () => {
               {
                 type: "file",
                 name: "emoji-data.txt",
-                path: "/emoji-data.txt",
+                path: "/ucd/emoji-data.txt",
                 lastModified: Date.now(),
               },
             ],

--- a/packages/ucd-store/test/maintenance/analyze.test.ts
+++ b/packages/ucd-store/test/maintenance/analyze.test.ts
@@ -33,7 +33,7 @@ const MOCK_FILES = [
       {
         type: "file",
         name: "DerivedBidiClass.txt",
-        path: "DerivedBidiClass.txt",
+        path: "extracted/DerivedBidiClass.txt",
         lastModified: 1724609100000,
       },
     ],

--- a/packages/ucd-store/test/maintenance/clean.test.ts
+++ b/packages/ucd-store/test/maintenance/clean.test.ts
@@ -37,7 +37,7 @@ describe("store clean", () => {
               {
                 type: "file",
                 name: "DerivedBidiClass.txt",
-                path: "DerivedBidiClass.txt",
+                path: "extracted/DerivedBidiClass.txt",
                 lastModified: 1724609100000,
               },
             ],

--- a/packages/ucd-store/test/maintenance/mirror.test.ts
+++ b/packages/ucd-store/test/maintenance/mirror.test.ts
@@ -37,7 +37,7 @@ describe("store mirror", () => {
               {
                 type: "file",
                 name: "DerivedBidiClass.txt",
-                path: "DerivedBidiClass.txt",
+                path: "extracted/DerivedBidiClass.txt",
                 lastModified: 1724609100000,
               },
             ],

--- a/packages/ucd-store/test/maintenance/repair.test.ts
+++ b/packages/ucd-store/test/maintenance/repair.test.ts
@@ -35,7 +35,7 @@ describe("store repair", () => {
               {
                 type: "file",
                 name: "DerivedBidiClass.txt",
-                path: "DerivedBidiClass.txt",
+                path: "extracted/DerivedBidiClass.txt",
                 lastModified: 1724609100000,
               },
             ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,8 +110,8 @@ catalogs:
       specifier: 5.0.48
       version: 5.0.48
     apache-autoindex-parse:
-      specifier: 3.0.3
-      version: 3.0.3
+      specifier: 4.0.3
+      version: 4.0.3
     debug:
       specifier: 4.4.3
       version: 4.4.3
@@ -316,7 +316,7 @@ importers:
         version: link:../../packages/utils
       apache-autoindex-parse:
         specifier: catalog:prod
-        version: 3.0.3
+        version: 4.0.3
       hono:
         specifier: catalog:workers
         version: 4.10.1
@@ -4959,8 +4959,8 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  apache-autoindex-parse@3.0.3:
-    resolution: {integrity: sha512-+BLXIGoiNpC8Hj9/XZYfs/zGu9noVAm0Vr4wqfADud3jJffgvkjdcD8836d/ROhxGwLDqDBAMrkeKuXjfE+rYQ==}
+  apache-autoindex-parse@4.0.3:
+    resolution: {integrity: sha512-fuaK6MjHm+pQmPoiYzCSfgU8HMFNwH+LJIo3/X9GtECTGXt0RTcfC4QdRrb8Yp3/PGGTkl8qRTDtPE0X1rGqEg==}
 
   archiver-utils@5.0.2:
     resolution: {integrity: sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==}
@@ -14820,7 +14820,7 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  apache-autoindex-parse@3.0.3: {}
+  apache-autoindex-parse@4.0.3: {}
 
   archiver-utils@5.0.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ minimumReleaseAgeExclude:
   - "@luxass/eslint-config"
   - "@luxass/unicode-utils"
   - "@luxass/msw-utils"
+  - apache-autoindex-parse
 
 packages:
   - "packages/*"
@@ -54,7 +55,7 @@ catalogs:
     ai: 5.0.48
     knitwork: 1.2.0
     picomatch: 4.0.3
-    apache-autoindex-parse: 3.0.3
+    apache-autoindex-parse: 4.0.3
     pathe: 2.0.3
     "@clack/prompts": 1.0.0-alpha.5
     debug: 4.4.3


### PR DESCRIPTION
### 🔗 Linked issue

resolves #369

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to UCDJS!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Updated test data to reflect normalized file path structure across multiple test suites.

* **Chores**
  * Upgraded apache-autoindex-parse dependency from 3.0.3 to 4.0.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->