### PR TITLE
fix(api): use correct file paths

### DIFF
--- a/apps/api/src/routes/v1_versions/$version.ts
+++ b/apps/api/src/routes/v1_versions/$version.ts
@@ -117,31 +117,31 @@ export const GET_VERSION_FILE_TREE_ROUTE = createRoute({
                 {
                   type: "file",
                   name: "ArabicShaping.txt",
-                  path: "ArabicShaping.txt",
+                  path: "/17.0.0/ucd/ArabicShaping.txt",
                   lastModified: 1724601900000,
                 },
                 {
                   type: "file",
                   name: "BidiBrackets.txt",
-                  path: "BidiBrackets.txt",
+                  path: "/17.0.0/ucd/BidiBrackets.txt",
                   lastModified: 1724601900000,
                 },
                 {
                   type: "directory",
                   name: "emoji",
-                  path: "emoji",
+                  path: "/17.0.0/ucd/emoji/",
                   lastModified: 1724669760000,
                   children: [
                     {
                       type: "file",
                       name: "ReadMe.txt",
-                      path: "ReadMe.txt",
+                      path: "/17.0.0/ucd/emoji/ReadMe.txt",
                       lastModified: 1724601900000,
                     },
                     {
                       type: "file",
                       name: "emoji-data.txt",
-                      path: "emoji-data.txt",
+                      path: "/17.0.0/ucd/emoji/emoji-data.txt",
                       lastModified: 1724601900000,
                     },
                   ],
@@ -254,6 +254,7 @@ export function registerVersionFileTreeRoute(router: OpenAPIHono<HonoEnv>) {
 
       const result = await traverse(`https://unicode.org/Public/${mappedVersion}${hasUCDFolderPath(mappedVersion) ? "/ucd" : ""}`, {
         format: "F2",
+        basePath: `/${mappedVersion}${hasUCDFolderPath(mappedVersion) ? "/ucd/" : "/"}`,
       });
 
       // We cast the result to UnicodeFileTree because the traverse function


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

This is a preparation for some of the other PRs. Some tests fail, which is fine.

But this will make all files paths relative to `/api/v1/files`, which is the new default.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to UCDJS!
----------------------------------------------------------------------->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated API file-tree route to return complete absolute file paths with version prefixes, improving path clarity and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->